### PR TITLE
KAS-4315: Subcase submission via the backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.DS_Store
+.idea
+*.log
+tmp/
+
+*.tern-port
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.tsbuildinfo
+.npm
+.eslintcache

--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -1,0 +1,10 @@
+pipeline:
+  build-and-push:
+    image: plugins/docker
+    settings:
+      repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
+      tags: "feature-${CI_COMMIT_BRANCH##feature/}"
+    secrets: [docker_username, docker_password]
+when:
+  event: push
+  branch: feature/*

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,0 +1,10 @@
+pipeline:
+  build-and-push:
+    image: plugins/docker
+    settings:
+      repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
+      tags: latest
+    secrets: [docker_username, docker_password]
+when:
+  event: push
+  branch: [master, main]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,0 +1,10 @@
+pipeline:
+  release:
+    image: plugins/docker
+    settings:
+      repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
+      tags: "${CI_COMMIT_TAG##v}"
+    secrets: [docker_username, docker_password]
+when:
+  event: tag
+  tag: v*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM semtech/mu-javascript-template:1.6.0
+FROM semtech/mu-javascript-template:1.7.0
 LABEL maintainer="Sergio Fenoll <sergio@fenoll.be>"
 
 # see https://github.com/mu-semtech/mu-javascript-template for more info

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,24 @@
+# The MIT License (MIT)
+
+  Copyright (c) 2024 Vlaamse Overheid
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# Agenda submission service
+
+Microservice used to submit subcases onto agendas in Kaleidos.
+
+## Tutorials
+
+### Add the service to a stack
+
+Add the following snippet to your `docker-compose.yml`:
+
+``` yaml
+agenda-submission:
+  image: kanselarij/agenda-submission-service
+```
+
+Add rules to the dispatcher configuration file to dispatch requests to this service:
+
+``` elixir
+match "/meetings/:meeting_id/submit", @json_service do
+  Proxy.forward conn, [], "http://agenda-submission/meetings/" <> meeting_id <> "/submit"
+end
+```
+
+## Reference
+
+### API
+
+#### POST `/meetings/:meeting_id/submit`
+
+Submit the subcase onto the latest agenda of the meeting.
+
+##### Request body
+
+``` json
+{
+  "subcase": "http://themis.vlaanderen.be/id/procedurestap/XXXXXX"
+}
+```
+
+##### Response
+
+###### 200 OK
+
+- When the submission the succeeded. The response body will contain bare JSON:API of the newly created agendaitem, providing only its ID so that it can be fetched using the resources service
+
+###### 400 Bad Request
+
+- When the meeting ID path parameter is left empty
+- When the subcase URI is not provided in the body of the request
+- When the provided meeting is already closed (you cannot submit a subcase on a closed meeting)
+- When the provided subcase is already submitted and is not postponed
+
+###### 404 Not Found
+
+- When the service cannot find data about either the meeting, the subcase, or the latest agenda of the meeting

--- a/app.js
+++ b/app.js
@@ -16,6 +16,8 @@ app.get('/', function(_req, res) {
 app.post('/meetings/:id/submit', async function(req, res, next) {
   const meetingId = req.params.id;
   const subcaseUri = req.body.subcase;
+  const formallyOk = req.body.formallyOk;
+  const privateComment = req.body.privateComment;
 
   if (!meetingId) {
     return next({ message: 'Path parameter meeting ID was not set, cannot proceed', status: 400 });
@@ -118,7 +120,7 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
     agenda: agenda.uri,
     title: subcase.title?.at(0),
     shortTitle: subcase.shortTitle?.at(0),
-    formallyOK: CONCEPTS.ACCEPTANCE_STATUSES.NOT_YET_OK,
+    formallyOk: formallyOk ? CONCEPTS.ACCEPTANCE_STATUSES.OK : CONCEPTS.ACCEPTANCE_STATUSES.NOT_YET_OK,
     number: agendaitemNumber,
     agendaitemType: subcase.agendaitemType.at(0),
     mandatees: subcase.mandatees,
@@ -126,6 +128,7 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
     linkedPieces: subcase.linkedPieces,
     agendaActivity: agendaActivity.uri,
     treatment: treatment.uri,
+    privateComment: privateComment,
   };
 
   let newsItem;

--- a/app.js
+++ b/app.js
@@ -95,7 +95,7 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
     uri: `${URI_BASES.decisionActivity}${decisionActivityId}`,
     startDate: meeting.plannedStart.at(0),
     subcase: subcaseUri,
-    secretary: meeting.secretary.at(0),
+    secretary: meeting.secretary?.at(0),
     ...(subcase.agendaitemType.at(0) === CONCEPTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT ? { decisionResultCode: CONCEPTS.DECISION_RESULT_CODES.ACKNOWLEDGED } : null)
   };
 

--- a/app.js
+++ b/app.js
@@ -1,25 +1,19 @@
 import {
   app,
   errorHandler,
-  query,
-  update,
-  sparqlEscapeUri,
-  sparqlEscapeString,
-  sparqlEscapeDateTime,
-  sparqlEscapeInt,
-  sparqlEscapeBool,
   uuid,
 } from 'mu';
-import { triplesToResources } from './lib/utils';
-import { CONCEPTS, TYPES, URI_BASES } from './constants';
+import { CONCEPTS, URI_BASES } from './constants';
+import { isMeetingClosed } from './lib/meeting';
+import { isSubcaseOnAgenda } from './lib/subcase';
+import { getRelatedResources } from './lib/data-fetching';
+import { persistRecords } from './lib/data-persisting';
 
 app.get('/', function(_req, res) {
   res.send('The agenda-submission-service is alive!');
 });
 
 app.post('/meetings/:id/submit', async function(req, res, next) {
-  console.debug(req.params);
-  console.debug(req.body);
   const meetingId = req.params.id;
   const subcaseUri = req.body.subcase;
 
@@ -31,228 +25,26 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
     return next({ message: 'Body does not contain a "subcase" field, cannot proceed', status: 400 });
    }
 
-  // Get latest agenda from meeting
-
-  // Get all submission activities and check if they're already linked to an agenda activity
-  // → If there are submission activities without agenda activities, use those
-  // → If none exist, create a new submission activity
-  // → Ensure that whatever submission activities are going to be linked have ALL the pieces
-  //
-  // Real cases are:
-  // - A new subcase which has 0 or 1 submission activities
-  //  → IFF submission activity exists, use it
-  //  → Else create new one
-  // - A postponed subcase which has 0 to * submission activities
-  //  → IFF no submission activity exists that is unlinked to an agenda activity, create new one and copy over ALL pieces from previous submission activities
-  //  → Else copy over all pieces from previous submission activities to unlinked submission activity
-
-  // Create agenda activity
-  // → Set start date
-  // → Link to subcase
-  // → Link to all submissionActivities
-
-  // Create decision activity
-  // → Set start date to meeting start date
-  // → Link to subcase
-  // → Link to decision result code
-  // → Link to meeting secretary
-
-  // Create agenda item treatment
-  // → Set created date
-  // → Set modified date
-  // → Link to decision activity
-
-  // For all pieces related to submission activities
-  // → Link new decision activity to sign flow if exists
-
-  // Calculate next agendaitem number
-  // Create agendaitem
-  // → Set created date
-  // → Set number
-  // → Link to agenda
-  // → Copy title from subcase
-  // → Copy shortTitle from subcase
-  // → Link to formally NOT OK
-  // → Link to agendaitem type from subcase
-  // → Link to mandatees from subcase
-  // → Link to pieces from submission activities
-  // → Link to linked pieces from subcase
-  // → Link to agenda activity
-  // → Link to agenda item treatment
-
-  // Set modified date on agenda
-
-  // Create news item if agendaitem is announcement
-
-  // Info needed from each resources:
-  // Meeting:
-  //  - Latest agenda
-  //  - Start date
-  //  - Secretary
-  //
-  // Subcase:
-  //  - Title
-  //  - Short title
-  //  - Mandatees
-  //  - Agendaitem type
-  //  - Linked pieces
-  //
-  // Submission activities:
-  //  - Pieces
-  //
-  // Pieces (from submission activities)
-  //  - Sign flow
-
-  const qIsMeetingClosed = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
-
-ASK
-WHERE {
-  VALUES ?meetingId {
-    ${sparqlEscapeString(meetingId)}
-  }
-
-  ?meeting mu:uuid ?meetingId ;
-    besluitvorming:behandelt ?agenda .
-}`;
-  let response = await query(qIsMeetingClosed);
-  if (response?.boolean) {
+  if (await isMeetingClosed(meetingId)) {
     return next({ message: 'This meeting is already closed, the provided subcase cannot be submitted to it', status: 400 });
   }
 
-  const qIsOnAgenda = `PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
-
-ASK
-WHERE {
-  VALUES ?subcase {
-    ${sparqlEscapeUri(subcaseUri)}
-  }
-  VALUES ?postponed {
-    ${sparqlEscapeUri(CONCEPTS.DECISION_RESULT_CODES.POSTPONED)}
-  }
-
-  ?agendaActivity besluitvorming:vindtPlaatsTijdens ?subcase ;
-                  besluitvorming:genereertAgendapunt ?agendaitem .
-  ?agenda dct:hasPart ?agendaitem .
-  ?agenda besluitvorming:isAgendaVoor ?meeting .
-  ?treatment dct:subject ?agendaitem ;
-             besluitvorming:heeftBeslissing ?decisionActivity .
-  FILTER NOT EXISTS {
-    ?decisionActivity besluitvorming:resultaat ?postponed .
-    ?internalDecisionPublicationActivityUsed ext:internalDecisionPublicationActivityUsed ?meeting ;
-                                             prov:startedAtTime ?startTime .
-  }
-}`;
-  response = await query(qIsOnAgenda);
-  if (response?.boolean) {
+  if (await isSubcaseOnAgenda(subcaseUri)) {
     return next({ message: 'The subcase is already submitted on an agenda and is not postponed, cannot resubmit it', status: 400 });
   }
 
-  const q = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
-PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
-PREFIX schema: <http://schema.org/>
+  const {
+    meeting,
+    agenda,
+    agendaitems,
+    subcase,
+    submissionActivities,
+    signFlows,
+  } = await getRelatedResources(meetingId, subcaseUri);
 
-CONSTRUCT {
-  ?meeting a ?meetingType ;
-    mu:uuid ?meetingId ;
-    besluit:geplandeStart ?plannedStart ;
-    ext:secretarisVoorVergadering ?secretary .
-  ?agenda a ?agendaType ;
-    besluitvorming:isAgendaVoor ?meeting .
-
-  ?subcase a ?subcaseType ;
-    dct:alternative ?shortTitle ;
-    ext:agendapuntType ?agendaItemType ;
-    dct:title ?title ;
-    ext:heeftBevoegde ?mandatee ;
-    ext:bevatReedsBezorgdeDocumentVersie ?linkedPiece .
-
-  ?submissionActivity ext:indieningVindtPlaatsTijdens ?subcase ;
-    prov:generated ?piece ;
-    a ?submissionActivityType .
-
-  ?agendaActivity prov:wasInformedBy ?submissionActivity .
-
-  ?signFlow a ?signFlowType ;
-    sign:heeftBeslissing ?decisionActivity .
-  ?agendaitem a ?_agendaitemType ;
-    schema:position ?agendaitemNumber .
-}
-WHERE {
-  VALUES (?meetingId ?subcase)
-  {
-    (${sparqlEscapeString(meetingId)} ${sparqlEscapeUri(subcaseUri)})
-  }
-  ?meeting a ?meetingType ;
-           mu:uuid ?meetingId ;
-           besluit:geplandeStart ?plannedStart ;
-           ^besluitvorming:isAgendaVoor ?agenda ;
-            ext:secretarisVoorVergadering ?secretary .
-  FILTER NOT EXISTS { ?newerAgenda prov:wasRevisionOf ?agenda }
-  ?agenda a ?agendaType .
-
-  ?subcase a ?subcaseType ;
-           dct:alternative ?shortTitle ;
-           ext:agendapuntType ?agendaItemType .
-  OPTIONAL { ?subcase dct:title ?title }
-  OPTIONAL { ?subcase ext:heeftBevoegde ?mandatee }
-  OPTIONAL { ?subcase ext:bevatReedsBezorgdeDocumentversie ?linkedPiece }
-  OPTIONAL {
-    ?submissionActivity ext:indieningVindtPlaatsTijdens ?subcase ;
-                        a ?submissionActivityType .
-    ?submissionActivity prov:generated ?piece .
-    OPTIONAL { ?agendaActivity prov:wasInformedBy ?submissionActivity }
-    OPTIONAL {
-      ?signMarkingActivity sign:gemarkeerdStuk ?piece ;
-        sign:markeringVindtPlaatsTijdens ?signSubcase .
-      ?signFlow a ?signFlowType ;
-        sign:doorlooptHandtekening ?signSubcase ;
-        sign:heeftBeslissing ?decisionActivity .
-    }
-  }
-  OPTIONAL {
-    ?agenda dct:hasPart ?agendaitem .
-    ?agendaitem a ?_agendaitemType ;
-      dct:type ?agendaItemType ;
-      schema:position ?agendaitemNumber .
-  }
-}`;
-
-  response = await query(q);
-
-  const resources = triplesToResources(response, {
-    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': 'a',
-    'http://www.w3.org/ns/prov#generated': 'pieces',
-    '^http://www.w3.org/ns/prov#wasInformedBy': 'agendaActivity',
-    'http://mu.semte.ch/vocabularies/ext/indieningVindtPlaatsTijdens': 'subcase',
-    'http://mu.semte.ch/vocabularies/ext/bevatReedsBezorgdeDocumentVersie': 'linkedPieces',
-    'http://mu.semte.ch/vocabularies/ext/heeftBevoegde': 'mandatees',
-    'http://mu.semte.ch/vocabularies/ext/agendapuntType': 'agendaitemType',
-    'http://purl.org/dc/terms/title': 'title',
-    'http://purl.org/dc/terms/alternative': 'shortTitle',
-    'http://mu.semte.ch/vocabularies/core/uuid': 'id',
-    'http://data.vlaanderen.be/ns/besluit#geplandeStart': 'plannedStart',
-    'http://mu.semte.ch/vocabularies/ext/secretarisVoorVergadering': 'secretary',
-    'https://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor': 'meeting',
-    'http://mu.semte.ch/vocabularies/ext/handtekenen/heeftBeslissing': 'decisionActivity',
-    'http://schema.org/position': 'number',
-  });
-
-  if (resources.length === 0) {
+  if (!meeting || !agenda || !subcase) {
     return next({ message: 'The necessary data to put the provided subcase on this meeting could not be found.', status: 404 });
   }
-
-  const submissionActivities = resources.filter((resource) => resource.a?.includes(TYPES.submissionActivity));
-  console.debug(resources);
-  console.debug(submissionActivities);
 
   const submissionsWithoutAnAgenda = submissionActivities.filter((resource) => !resource.agendaActivity);
   const allPieces = [...new Set(submissionActivities.flatMap((resource) => resource.pieces))];
@@ -272,8 +64,6 @@ WHERE {
     // If all pieces for submission are in submission without an agenda, do nothing
     // Otherwise create a new submission
     const unsubmittedPieces = [...new Set(submissionsWithoutAnAgenda.flatMap((resource) => resource.pieces))];
-    console.debug('allPieces:', allPieces);
-    console.debug('unsubmittedPieces:', unsubmittedPieces);
     const difference = allPieces.filter((piece) => !unsubmittedPieces.includes(piece));
 
     if (difference.length) {
@@ -298,14 +88,6 @@ WHERE {
       ? [...submissionsWithoutAnAgenda, newSubmission]
       : submissionsWithoutAnAgenda,
   };
-  console.debug('agendaActivity:', agendaActivity);
-
-  const meeting = resources.filter((resource) => resource.a?.includes(TYPES.meeting)).at(0);
-  const subcase = resources.filter((resource) => resource.a?.includes(TYPES.subcase)).at(0);
-  const signFlows = resources.filter((resource) => resource.a?.includes(TYPES.signFlow));
-
-  console.debug('meeting:', meeting);
-  console.debug('subcase:', subcase);
 
   const decisionActivityId = uuid();
   const decisionActivity = {
@@ -327,8 +109,6 @@ WHERE {
     decisionActivity: decisionActivity.uri,
   };
 
-  const agenda = resources.filter((resource) => resource.a?.includes(TYPES.agenda)).at(0);
-  const agendaitems = resources.filter((resource) => resource.a?.includes(TYPES.agendaitem));
   const agendaitemNumber = 1 + Math.max(0, ...agendaitems.map((agendaitem) => agendaitem.number.at(0)));
   const agendaitemId = uuid();
   const agendaitem = {
@@ -347,7 +127,6 @@ WHERE {
     agendaActivity: agendaActivity.uri,
     treatment: treatment.uri,
   };
-  console.debug(agendaitem);
 
   let newsItem;
   if (subcase.agendaitemType.at(0) === CONCEPTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT) {
@@ -363,93 +142,23 @@ WHERE {
     };
   }
 
-  let qUpdate = `PREFIX schema: <http://schema.org/>
-PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
-PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
-PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+  await persistRecords({
+    agendaitem,
+    treatment,
+    agendaActivity,
+    decisionActivity,
+    newSubmission,
+    newsItem,
+    agenda,
+    signFlows,
+  });
 
-DELETE {
-  ${sparqlEscapeUri(agenda.uri)} dct:modified ?oldModified .
-  ${signFlows.length ? signFlows.map((signFlow) => {
-    return `${sparqlEscapeUri(signFlow.uri)} sign:heeftBeslissing ${sparqlEscapeUri(signFlow.decisionActivity.at(0))} .`
-  }).join('  \n') : ''}
-} INSERT {`;
-  if (newSubmission) {
-    qUpdate += `
-  ${sparqlEscapeUri(newSubmission.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.submissionActivity)} ;
-    mu:uuid ${sparqlEscapeString(newSubmission.id)} ;
-    dossier:Activiteit.startdatum ${sparqlEscapeDateTime(newSubmission.startDate)} ;
-    ${newSubmission.pieces?.length ? `prov:generated ${newSubmission.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
-    ext:indieningVindtPlaatsTijdens ${sparqlEscapeUri(newSubmission.subcase)} .`;
-  }
-
-  if (newsItem) {
-    qUpdate += `
-  ${sparqlEscapeUri(newsItem.uri)} a ${sparqlEscapeUri(TYPES.newsItem)} ;
-    mu:uuid ${sparqlEscapeString(newsItem.id)} ;
-    prov:wasDerivedFrom ${sparqlEscapeUri(newsItem.treatment)} ;
-    dct:title ${sparqlEscapeString(newsItem.title)} ;
-    ${newsItem.htmlContent ? `nie:htmlContent ${sparqlEscapeString(newsItem.htmlContent)} ;` : ''}
-    ext:afgewerkt ${sparqlEscapeBool(newsItem.finished)} ;
-    ext:inNieuwsbrief ${sparqlEscapeBool(newsItem.inNewsletter)} .`;
-  }
-
-  qUpdate += `
-  ${sparqlEscapeUri(agendaActivity.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.agendaActivity)} ;
-    mu:uuid ${sparqlEscapeString(agendaActivity.id)} ;
-    dossier:startDatum ${sparqlEscapeDateTime(agendaActivity.startDate)} ;
-    besluitvorming:vindtPlaatsTijdens ${sparqlEscapeUri(agendaActivity.subcase)} ;
-    prov:wasInformedBy ${agendaActivity.submissionActivities.map((a) => sparqlEscapeUri(a.uri)).join(', ')} .`;
-
-  qUpdate += `
-  ${sparqlEscapeUri(decisionActivity.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.decisionActivity)} ;
-    mu:uuid ${sparqlEscapeString(decisionActivity.id)} ;
-    ${decisionActivity.secretary ? `prov:wasAssociatedWith ${sparqlEscapeUri(decisionActivity.secretary)} ;` : ''}
-    ${decisionActivity.decisionResultCode ? `besluitvorming:resultaat ${sparqlEscapeUri(decisionActivity.decisionResultCode)} ;` : ''}
-    dossier:Activiteit.startdatum ${sparqlEscapeDateTime(decisionActivity.startDate)} ;
-    ext:beslissingVindtPlaatsTijdens ${sparqlEscapeUri(decisionActivity.subcase)} .`;
-
-  qUpdate += `
-  ${sparqlEscapeUri(treatment.uri)} a ${sparqlEscapeUri(TYPES.treatment)} ;
-    mu:uuid ${sparqlEscapeString(treatment.id)} ;
-    dct:created ${sparqlEscapeDateTime(treatment.created)} ;
-    dct:modified ${sparqlEscapeDateTime(treatment.modified)} ;
-    besluitvorming:heeftBeslissing ${sparqlEscapeUri(treatment.decisionActivity)} .`;
-
-  qUpdate += `
-  ${sparqlEscapeUri(agendaitem.uri)} a ${sparqlEscapeUri(TYPES.agendaitem)} ;
-    mu:uuid ${sparqlEscapeString(agendaitem.id)} ;
-    dct:created ${sparqlEscapeDateTime(agendaitem.created)} ;
-    schema:position ${sparqlEscapeInt(agendaitem.number)} ;
-    besluitvorming:korteTitel ${sparqlEscapeString(agendaitem.shortTitle)} ;
-    ${agendaitem.title ? `dct:title ${sparqlEscapeString(agendaitem.title)} ;` : ''}
-    ext:formeelOK ${sparqlEscapeUri(agendaitem.formallyOK)} ;
-    ${agendaitem.mandatees?.length ? `ext:heeftBevoegdeVoorAgendapunt ${agendaitem.mandatees.map(sparqlEscapeUri).join(', ')} ;` : ''}
-    ${agendaitem.pieces?.length ? `besluitvorming:geagendeerdStuk ${agendaitem.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
-    ${agendaitem.linkedPieces?.length ? `ext:bevatReedsBezorgdAgendapuntDocumentversie ${agendaitem.linkedPieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
-    dct:type ${sparqlEscapeUri(agendaitem.agendaitemType)} .
-
-  ${sparqlEscapeUri(agendaitem.treatment)} dct:subject ${sparqlEscapeUri(agendaitem.uri)} .
-  ${sparqlEscapeUri(agendaitem.agendaActivity)} besluitvorming:genereertAgendapunt ${sparqlEscapeUri(agendaitem.uri)} .
-  ${sparqlEscapeUri(agendaitem.agenda)} dct:hasPart ${sparqlEscapeUri(agendaitem.uri)} .`;
-
-  qUpdate += `
-  ${sparqlEscapeUri(agenda.uri)} dct:modified ${sparqlEscapeDateTime(new Date())} .
-  ${signFlows.length ? signFlows.map((signFlow) => {
-    return `${sparqlEscapeUri(signFlow.uri)} sign:heeftBeslissing ${sparqlEscapeUri(decisionActivity.uri)} .`
-  }).join('  \n') : ''}
-} WHERE {
-  ${sparqlEscapeUri(agenda.uri)} dct:modified ?oldModified .
-}`;
-
-  await update(qUpdate);
-
+  /**
+   * Pipe dream: instead of responding with nothing, we should tally up all the
+   * new records and return them from this call so that the frontend can load
+   * them and "know" that they exist, so that we're not at risk of being behind
+   * the cache invalidation.
+   */
   return res.sendStatus(204);
 });
 

--- a/app.js
+++ b/app.js
@@ -154,12 +154,21 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
   });
 
   /**
-   * Pipe dream: instead of responding with nothing, we should tally up all the
-   * new records and return them from this call so that the frontend can load
-   * them and "know" that they exist, so that we're not at risk of being behind
-   * the cache invalidation.
+   * Pipe dream: instead of sleeping and responding with one thing, we should
+   * tally up all the new records and return them from this call so that the
+   * frontend can load them and "know" that they exist, so that we're not at
+   * risk of being behind the cache invalidation. This is the way interactions
+   * with the resources service work. It's not inherently faster at cache
+   * resolution, it just tells the frontend what has been made and the frontend
+   * then doesn't try to fetch that data.
    */
-  return res.sendStatus(204);
+  await new Promise((resolve) => setTimeout(resolve, 4000));
+  return res.status(200).send({
+    data: {
+      type: 'agendaitems',
+      id: agendaitem.id,
+    }
+  });
 });
 
 app.use(errorHandler);

--- a/app.js
+++ b/app.js
@@ -1,9 +1,456 @@
-// see https://github.com/mu-semtech/mu-javascript-template for more info
+import {
+  app,
+  errorHandler,
+  query,
+  update,
+  sparqlEscapeUri,
+  sparqlEscapeString,
+  sparqlEscapeDateTime,
+  sparqlEscapeInt,
+  sparqlEscapeBool,
+  uuid,
+} from 'mu';
+import { triplesToResources } from './lib/utils';
+import { CONCEPTS, TYPES, URI_BASES } from './constants';
 
-import { app, query, errorHandler } from 'mu';
+app.get('/', function(_req, res) {
+  res.send('The agenda-submission-service is alive!');
+});
 
-app.get('/', function( req, res ) {
-  res.send('Hello mu-javascript-template');
-} );
+app.post('/meetings/:id/submit', async function(req, res, next) {
+  console.debug(req.params);
+  console.debug(req.body);
+  const meetingId = req.params.id;
+  const subcaseUri = req.body.subcase;
+
+  if (!meetingId) {
+    return next({ message: 'Path parameter meeting ID was not set, cannot proceed', status: 400 });
+  }
+
+   if (!subcaseUri) {
+    return next({ message: 'Body does not contain a "subcase" field, cannot proceed', status: 400 });
+   }
+
+  // Get latest agenda from meeting
+
+  // Get all submission activities and check if they're already linked to an agenda activity
+  // → If there are submission activities without agenda activities, use those
+  // → If none exist, create a new submission activity
+  // → Ensure that whatever submission activities are going to be linked have ALL the pieces
+  //
+  // Real cases are:
+  // - A new subcase which has 0 or 1 submission activities
+  //  → IFF submission activity exists, use it
+  //  → Else create new one
+  // - A postponed subcase which has 0 to * submission activities
+  //  → IFF no submission activity exists that is unlinked to an agenda activity, create new one and copy over ALL pieces from previous submission activities
+  //  → Else copy over all pieces from previous submission activities to unlinked submission activity
+
+  // Create agenda activity
+  // → Set start date
+  // → Link to subcase
+  // → Link to all submissionActivities
+
+  // Create decision activity
+  // → Set start date to meeting start date
+  // → Link to subcase
+  // → Link to decision result code
+  // → Link to meeting secretary
+
+  // Create agenda item treatment
+  // → Set created date
+  // → Set modified date
+  // → Link to decision activity
+
+  // For all pieces related to submission activities
+  // → Link new decision activity to sign flow if exists
+
+  // Calculate next agendaitem number
+  // Create agendaitem
+  // → Set created date
+  // → Set number
+  // → Link to agenda
+  // → Copy title from subcase
+  // → Copy shortTitle from subcase
+  // → Link to formally NOT OK
+  // → Link to agendaitem type from subcase
+  // → Link to mandatees from subcase
+  // → Link to pieces from submission activities
+  // → Link to linked pieces from subcase
+  // → Link to agenda activity
+  // → Link to agenda item treatment
+
+  // Set modified date on agenda
+
+  // Create news item if agendaitem is announcement
+
+  // Info needed from each resources:
+  // Meeting:
+  //  - Latest agenda
+  //  - Start date
+  //  - Secretary
+  //
+  // Subcase:
+  //  - Title
+  //  - Short title
+  //  - Mandatees
+  //  - Agendaitem type
+  //  - Linked pieces
+  //
+  // Submission activities:
+  //  - Pieces
+  //
+  // Pieces (from submission activities)
+  //  - Sign flow
+
+  const qIsMeetingClosed = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+
+ASK
+WHERE {
+  VALUES ?meetingId {
+    ${sparqlEscapeString(meetingId)}
+  }
+
+  ?meeting mu:uuid ?meetingId ;
+    besluitvorming:behandelt ?agenda .
+}`;
+  let response = await query(qIsMeetingClosed);
+  if (response?.boolean) {
+    return next({ message: 'This meeting is already closed, the provided subcase cannot be submitted to it', status: 400 });
+  }
+
+  const qIsOnAgenda = `PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+
+ASK
+WHERE {
+  VALUES ?subcase {
+    ${sparqlEscapeUri(subcaseUri)}
+  }
+  VALUES ?postponed {
+    ${sparqlEscapeUri(CONCEPTS.DECISION_RESULT_CODES.POSTPONED)}
+  }
+
+  ?agendaActivity besluitvorming:vindtPlaatsTijdens ?subcase ;
+                  besluitvorming:genereertAgendapunt ?agendaitem .
+  ?agenda dct:hasPart ?agendaitem .
+  ?agenda besluitvorming:isAgendaVoor ?meeting .
+  ?treatment dct:subject ?agendaitem ;
+             besluitvorming:heeftBeslissing ?decisionActivity .
+  FILTER NOT EXISTS {
+    ?decisionActivity besluitvorming:resultaat ?postponed .
+    ?internalDecisionPublicationActivityUsed ext:internalDecisionPublicationActivityUsed ?meeting ;
+                                             prov:startedAtTime ?startTime .
+  }
+}`;
+  response = await query(qIsOnAgenda);
+  if (response?.boolean) {
+    return next({ message: 'The subcase is already submitted on an agenda and is not postponed, cannot resubmit it', status: 400 });
+  }
+
+  const q = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+PREFIX schema: <http://schema.org/>
+
+CONSTRUCT {
+  ?meeting a ?meetingType ;
+    mu:uuid ?meetingId ;
+    besluit:geplandeStart ?plannedStart ;
+    ext:secretarisVoorVergadering ?secretary .
+  ?agenda a ?agendaType ;
+    besluitvorming:isAgendaVoor ?meeting .
+
+  ?subcase a ?subcaseType ;
+    dct:alternative ?shortTitle ;
+    ext:agendapuntType ?agendaItemType ;
+    dct:title ?title ;
+    ext:heeftBevoegde ?mandatee ;
+    ext:bevatReedsBezorgdeDocumentVersie ?linkedPiece .
+
+  ?submissionActivity ext:indieningVindtPlaatsTijdens ?subcase ;
+    prov:generated ?piece ;
+    a ?submissionActivityType .
+
+  ?agendaActivity prov:wasInformedBy ?submissionActivity .
+
+  ?signFlow a ?signFlowType ;
+    sign:heeftBeslissing ?decisionActivity .
+  ?agendaitem a ?_agendaitemType ;
+    schema:position ?agendaitemNumber .
+}
+WHERE {
+  VALUES (?meetingId ?subcase)
+  {
+    (${sparqlEscapeString(meetingId)} ${sparqlEscapeUri(subcaseUri)})
+  }
+  ?meeting a ?meetingType ;
+           mu:uuid ?meetingId ;
+           besluit:geplandeStart ?plannedStart ;
+           ^besluitvorming:isAgendaVoor ?agenda ;
+            ext:secretarisVoorVergadering ?secretary .
+  FILTER NOT EXISTS { ?newerAgenda prov:wasRevisionOf ?agenda }
+  ?agenda a ?agendaType .
+
+  ?subcase a ?subcaseType ;
+           dct:alternative ?shortTitle ;
+           ext:agendapuntType ?agendaItemType .
+  OPTIONAL { ?subcase dct:title ?title }
+  OPTIONAL { ?subcase ext:heeftBevoegde ?mandatee }
+  OPTIONAL { ?subcase ext:bevatReedsBezorgdeDocumentversie ?linkedPiece }
+  OPTIONAL {
+    ?submissionActivity ext:indieningVindtPlaatsTijdens ?subcase ;
+                        a ?submissionActivityType .
+    ?submissionActivity prov:generated ?piece .
+    OPTIONAL { ?agendaActivity prov:wasInformedBy ?submissionActivity }
+    OPTIONAL {
+      ?signMarkingActivity sign:gemarkeerdStuk ?piece ;
+        sign:markeringVindtPlaatsTijdens ?signSubcase .
+      ?signFlow a ?signFlowType ;
+        sign:doorlooptHandtekening ?signSubcase ;
+        sign:heeftBeslissing ?decisionActivity .
+    }
+  }
+  OPTIONAL {
+    ?agenda dct:hasPart ?agendaitem .
+    ?agendaitem a ?_agendaitemType ;
+      dct:type ?agendaItemType ;
+      schema:position ?agendaitemNumber .
+  }
+}`;
+
+  response = await query(q);
+
+  const resources = triplesToResources(response, {
+    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': 'a',
+    'http://www.w3.org/ns/prov#generated': 'pieces',
+    '^http://www.w3.org/ns/prov#wasInformedBy': 'agendaActivity',
+    'http://mu.semte.ch/vocabularies/ext/indieningVindtPlaatsTijdens': 'subcase',
+    'http://mu.semte.ch/vocabularies/ext/bevatReedsBezorgdeDocumentVersie': 'linkedPieces',
+    'http://mu.semte.ch/vocabularies/ext/heeftBevoegde': 'mandatees',
+    'http://mu.semte.ch/vocabularies/ext/agendapuntType': 'agendaitemType',
+    'http://purl.org/dc/terms/title': 'title',
+    'http://purl.org/dc/terms/alternative': 'shortTitle',
+    'http://mu.semte.ch/vocabularies/core/uuid': 'id',
+    'http://data.vlaanderen.be/ns/besluit#geplandeStart': 'plannedStart',
+    'http://mu.semte.ch/vocabularies/ext/secretarisVoorVergadering': 'secretary',
+    'https://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor': 'meeting',
+    'http://mu.semte.ch/vocabularies/ext/handtekenen/heeftBeslissing': 'decisionActivity',
+    'http://schema.org/position': 'number',
+  });
+
+  if (resources.length === 0) {
+    return next({ message: 'The necessary data to put the provided subcase on this meeting could not be found.', status: 404 });
+  }
+
+  const submissionActivities = resources.filter((resource) => resource.a?.includes(TYPES.submissionActivity));
+  console.debug(resources);
+  console.debug(submissionActivities);
+
+  const submissionsWithoutAnAgenda = submissionActivities.filter((resource) => !resource.agendaActivity);
+  const allPieces = [...new Set(submissionActivities.flatMap((resource) => resource.pieces))];
+  let newSubmission;
+
+  if (submissionsWithoutAnAgenda.length === 0) {
+    // Create a new submissionActivity
+    const newSubmissionId = uuid();
+    newSubmission = {
+      id: newSubmissionId,
+      uri: `${URI_BASES.submissionActivity}${newSubmissionId}`,
+      startDate: new Date(),
+      subcase: subcaseUri,
+      pieces: allPieces,
+    };
+  } else {
+    // If all pieces for submission are in submission without an agenda, do nothing
+    // Otherwise create a new submission
+    const unsubmittedPieces = [...new Set(submissionsWithoutAnAgenda.flatMap((resource) => resource.pieces))];
+    console.debug('allPieces:', allPieces);
+    console.debug('unsubmittedPieces:', unsubmittedPieces);
+    const difference = allPieces.filter((piece) => !unsubmittedPieces.includes(piece));
+
+    if (difference.length) {
+      const newSubmissionId = uuid();
+      newSubmission = {
+        id: newSubmissionId,
+        uri: `${URI_BASES.submissionActivity}${newSubmissionId}`,
+        startDate: new Date(),
+        subcase: subcaseUri,
+        pieces: difference,
+      };
+    }
+  }
+
+  const agendaActivityId = uuid();
+  const agendaActivity = {
+    id: agendaActivityId,
+    uri: `${URI_BASES.agendaActivity}${agendaActivityId}`,
+    startDate: new Date(),
+    subcase: subcaseUri,
+    submissionActivities: newSubmission
+      ? [...submissionsWithoutAnAgenda, newSubmission]
+      : submissionsWithoutAnAgenda,
+  };
+  console.debug('agendaActivity:', agendaActivity);
+
+  const meeting = resources.filter((resource) => resource.a?.includes(TYPES.meeting)).at(0);
+  const subcase = resources.filter((resource) => resource.a?.includes(TYPES.subcase)).at(0);
+  const signFlows = resources.filter((resource) => resource.a?.includes(TYPES.signFlow));
+
+  console.debug('meeting:', meeting);
+  console.debug('subcase:', subcase);
+
+  const decisionActivityId = uuid();
+  const decisionActivity = {
+    id: decisionActivityId,
+    uri: `${URI_BASES.decisionActivity}${decisionActivityId}`,
+    startDate: meeting.plannedStart.at(0),
+    subcase: subcaseUri,
+    secretary: meeting.secretary.at(0),
+    ...(subcase.agendaitemType.at(0) === CONCEPTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT ? { decisionResultCode: CONCEPTS.DECISION_RESULT_CODES.ACKNOWLEDGED } : null)
+  };
+
+  const now = new Date();
+  const treatmentId = uuid();
+  const treatment = {
+    id: treatmentId,
+    uri: `${URI_BASES.treatment}${treatmentId}`,
+    created: now,
+    modified: now,
+    decisionActivity: decisionActivity.uri,
+  };
+
+  const agenda = resources.filter((resource) => resource.a?.includes(TYPES.agenda)).at(0);
+  const agendaitems = resources.filter((resource) => resource.a?.includes(TYPES.agendaitem));
+  const agendaitemNumber = 1 + Math.max(0, ...agendaitems.map((agendaitem) => agendaitem.number.at(0)));
+  const agendaitemId = uuid();
+  const agendaitem = {
+    id: agendaitemId,
+    uri: `${URI_BASES.agendaitem}${agendaitemId}`,
+    created: new Date(),
+    agenda: agenda.uri,
+    title: subcase.title?.at(0),
+    shortTitle: subcase.shortTitle?.at(0),
+    formallyOK: CONCEPTS.ACCEPTANCE_STATUSES.NOT_YET_OK,
+    number: agendaitemNumber,
+    agendaitemType: subcase.agendaitemType.at(0),
+    mandatees: subcase.mandatees,
+    pieces: allPieces,
+    linkedPieces: subcase.linkedPieces,
+    agendaActivity: agendaActivity.uri,
+    treatment: treatment.uri,
+  };
+  console.debug(agendaitem);
+
+  let newsItem;
+  if (subcase.agendaitemType.at(0) === CONCEPTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT) {
+    const newsItemId = uuid();
+    newsItem = {
+      id: newsItemId,
+      uri: `${URI_BASES.newsItem}${newsItemId}`,
+      treatment: treatment.uri,
+      title: agendaitem.shortTitle ?? agendaitem.title,
+      htmlContent: agendaitem.title,
+      finished: true,
+      inNewsletter: true,
+    };
+  }
+
+  let qUpdate = `PREFIX schema: <http://schema.org/>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+DELETE {
+  ${sparqlEscapeUri(agenda.uri)} dct:modified ?oldModified .
+  ${signFlows.length ? signFlows.map((signFlow) => {
+    return `${sparqlEscapeUri(signFlow.uri)} sign:heeftBeslissing ${sparqlEscapeUri(signFlow.decisionActivity.at(0))} .`
+  }).join('  \n') : ''}
+} INSERT {`;
+  if (newSubmission) {
+    qUpdate += `
+  ${sparqlEscapeUri(newSubmission.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.submissionActivity)} ;
+    mu:uuid ${sparqlEscapeString(newSubmission.id)} ;
+    dossier:Activiteit.startdatum ${sparqlEscapeDateTime(newSubmission.startDate)} ;
+    ${newSubmission.pieces?.length ? `prov:generated ${newSubmission.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ext:indieningVindtPlaatsTijdens ${sparqlEscapeUri(newSubmission.subcase)} .`;
+  }
+
+  if (newsItem) {
+    qUpdate += `
+  ${sparqlEscapeUri(newsItem.uri)} a ${sparqlEscapeUri(TYPES.newsItem)} ;
+    mu:uuid ${sparqlEscapeString(newsItem.id)} ;
+    prov:wasDerivedFrom ${sparqlEscapeUri(newsItem.treatment)} ;
+    dct:title ${sparqlEscapeString(newsItem.title)} ;
+    ${newsItem.htmlContent ? `nie:htmlContent ${sparqlEscapeString(newsItem.htmlContent)} ;` : ''}
+    ext:afgewerkt ${sparqlEscapeBool(newsItem.finished)} ;
+    ext:inNieuwsbrief ${sparqlEscapeBool(newsItem.inNewsletter)} .`;
+  }
+
+  qUpdate += `
+  ${sparqlEscapeUri(agendaActivity.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.agendaActivity)} ;
+    mu:uuid ${sparqlEscapeString(agendaActivity.id)} ;
+    dossier:startDatum ${sparqlEscapeDateTime(agendaActivity.startDate)} ;
+    besluitvorming:vindtPlaatsTijdens ${sparqlEscapeUri(agendaActivity.subcase)} ;
+    prov:wasInformedBy ${agendaActivity.submissionActivities.map((a) => sparqlEscapeUri(a.uri)).join(', ')} .`;
+
+  qUpdate += `
+  ${sparqlEscapeUri(decisionActivity.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.decisionActivity)} ;
+    mu:uuid ${sparqlEscapeString(decisionActivity.id)} ;
+    ${decisionActivity.secretary ? `prov:wasAssociatedWith ${sparqlEscapeUri(decisionActivity.secretary)} ;` : ''}
+    ${decisionActivity.decisionResultCode ? `besluitvorming:resultaat ${sparqlEscapeUri(decisionActivity.decisionResultCode)} ;` : ''}
+    dossier:Activiteit.startdatum ${sparqlEscapeDateTime(decisionActivity.startDate)} ;
+    ext:beslissingVindtPlaatsTijdens ${sparqlEscapeUri(decisionActivity.subcase)} .`;
+
+  qUpdate += `
+  ${sparqlEscapeUri(treatment.uri)} a ${sparqlEscapeUri(TYPES.treatment)} ;
+    mu:uuid ${sparqlEscapeString(treatment.id)} ;
+    dct:created ${sparqlEscapeDateTime(treatment.created)} ;
+    dct:modified ${sparqlEscapeDateTime(treatment.modified)} ;
+    besluitvorming:heeftBeslissing ${sparqlEscapeUri(treatment.decisionActivity)} .`;
+
+  qUpdate += `
+  ${sparqlEscapeUri(agendaitem.uri)} a ${sparqlEscapeUri(TYPES.agendaitem)} ;
+    mu:uuid ${sparqlEscapeString(agendaitem.id)} ;
+    dct:created ${sparqlEscapeDateTime(agendaitem.created)} ;
+    schema:position ${sparqlEscapeInt(agendaitem.number)} ;
+    besluitvorming:korteTitel ${sparqlEscapeString(agendaitem.shortTitle)} ;
+    ${agendaitem.title ? `dct:title ${sparqlEscapeString(agendaitem.title)} ;` : ''}
+    ext:formeelOK ${sparqlEscapeUri(agendaitem.formallyOK)} ;
+    ${agendaitem.mandatees?.length ? `ext:heeftBevoegdeVoorAgendapunt ${agendaitem.mandatees.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ${agendaitem.pieces?.length ? `besluitvorming:geagendeerdStuk ${agendaitem.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ${agendaitem.linkedPieces?.length ? `ext:bevatReedsBezorgdAgendapuntDocumentversie ${agendaitem.linkedPieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    dct:type ${sparqlEscapeUri(agendaitem.agendaitemType)} .
+
+  ${sparqlEscapeUri(agendaitem.treatment)} dct:subject ${sparqlEscapeUri(agendaitem.uri)} .
+  ${sparqlEscapeUri(agendaitem.agendaActivity)} besluitvorming:genereertAgendapunt ${sparqlEscapeUri(agendaitem.uri)} .
+  ${sparqlEscapeUri(agendaitem.agenda)} dct:hasPart ${sparqlEscapeUri(agendaitem.uri)} .`;
+
+  qUpdate += `
+  ${sparqlEscapeUri(agenda.uri)} dct:modified ${sparqlEscapeDateTime(new Date())} .
+  ${signFlows.length ? signFlows.map((signFlow) => {
+    return `${sparqlEscapeUri(signFlow.uri)} sign:heeftBeslissing ${sparqlEscapeUri(decisionActivity.uri)} .`
+  }).join('  \n') : ''}
+} WHERE {
+  ${sparqlEscapeUri(agenda.uri)} dct:modified ?oldModified .
+}`;
+
+  await update(qUpdate);
+
+  return res.sendStatus(204);
+});
 
 app.use(errorHandler);

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,41 @@
+const TYPES = {
+  activity: 'http://www.w3.org/ns/prov#Activity',
+  submissionActivity: 'http://mu.semte.ch/vocabularies/ext/Indieningsactiviteit',
+  agendaActivity: 'https://data.vlaanderen.be/ns/besluitvorming#Agendering',
+  decisionActivity: 'https://data.vlaanderen.be/ns/besluitvorming#Beslissingsactiviteit',
+  treatment: 'http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt',
+  agendaitem: 'http://data.vlaanderen.be/ns/besluit#Agendapunt',
+  agenda: 'https://data.vlaanderen.be/ns/besluitvorming#Agenda',
+  meeting: 'http://data.vlaanderen.be/ns/besluit#Vergaderactiviteit',
+  subcase: 'https://data.vlaanderen.be/ns/dossier#Procedurestap',
+  newsItem: 'http://mu.semte.ch/vocabularies/ext/Nieuwsbericht',
+  signFlow: 'http://mu.semte.ch/vocabularies/ext/handtekenen/Handtekenaangelegenheid',
+};
+
+const CONCEPTS = {
+  DECISION_RESULT_CODES: {
+    POSTPONED: 'http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/a29b3ffd-0839-45cb-b8f4-e1760f7aacaa',
+    ACKNOWLEDGED: 'http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/9f342a88-9485-4a83-87d9-245ed4b504bf',
+  },
+  ACCEPTANCE_STATUSES: {
+    NOT_YET_OK: 'http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/B72D1561-8172-466B-B3B6-FCC372C287D0',
+  },
+  AGENDA_ITEM_TYPES: {
+    ANNOUNCEMENT: 'http://themis.vlaanderen.be/id/concept/agendapunt-type/8f8adcf0-58ef-4edc-9e36-0c9095fd76b0',
+  },
+};
+
+const URI_BASES = {
+  agendaActivity: 'http://themis.vlaanderen.be/id/agendering/',
+  decisionActivity: 'http://themis.vlaanderen.be/id/beslissingsactiviteit/',
+  submissionActivity: 'http://kanselarij.vo.data.gift/id/indieningsactiviteit/',
+  treatment: 'http://themis.vlaanderen.be/id/behandeling-van-agendapunt/',
+  newsItem: 'http://themis.vlaanderen.be/id/nieuwsbericht/',
+  agendaitem: 'http://themis.vlaanderen.be/id/agendapunt/',
+};
+
+export {
+  TYPES,
+  CONCEPTS,
+  URI_BASES,
+}

--- a/constants.js
+++ b/constants.js
@@ -19,6 +19,7 @@ const CONCEPTS = {
   },
   ACCEPTANCE_STATUSES: {
     NOT_YET_OK: 'http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/B72D1561-8172-466B-B3B6-FCC372C287D0',
+    OK: 'http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/CC12A7DB-A73A-4589-9D53-F3C2F4A40636',
   },
   AGENDA_ITEM_TYPES: {
     ANNOUNCEMENT: 'http://themis.vlaanderen.be/id/concept/agendapunt-type/8f8adcf0-58ef-4edc-9e36-0c9095fd76b0',

--- a/lib/data-fetching.js
+++ b/lib/data-fetching.js
@@ -1,0 +1,119 @@
+import { query, sparqlEscapeString, sparqlEscapeUri } from 'mu';
+import { responseToTriples, triplesToResources } from './utils';
+import { TYPES } from '../constants';
+
+async function getRelatedResources(meetingId, subcaseUri) {
+  const response = await getRelatedData(meetingId, subcaseUri);
+  const triples = responseToTriples(response);
+  const resources = triplesToResources(triples, {
+    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': 'a',
+    'http://www.w3.org/ns/prov#generated': 'pieces',
+    '^http://www.w3.org/ns/prov#wasInformedBy': 'agendaActivity',
+    'http://mu.semte.ch/vocabularies/ext/indieningVindtPlaatsTijdens': 'subcase',
+    'http://mu.semte.ch/vocabularies/ext/bevatReedsBezorgdeDocumentVersie': 'linkedPieces',
+    'http://mu.semte.ch/vocabularies/ext/heeftBevoegde': 'mandatees',
+    'http://mu.semte.ch/vocabularies/ext/agendapuntType': 'agendaitemType',
+    'http://purl.org/dc/terms/title': 'title',
+    'http://purl.org/dc/terms/alternative': 'shortTitle',
+    'http://mu.semte.ch/vocabularies/core/uuid': 'id',
+    'http://data.vlaanderen.be/ns/besluit#geplandeStart': 'plannedStart',
+    'http://mu.semte.ch/vocabularies/ext/secretarisVoorVergadering': 'secretary',
+    'https://data.vlaanderen.be/ns/besluitvorming#isAgendaVoor': 'meeting',
+    'http://mu.semte.ch/vocabularies/ext/handtekenen/heeftBeslissing': 'decisionActivity',
+    'http://schema.org/position': 'number',
+  });
+
+  const resourcesByType = (type) => resources.filter((resource) => resource.a?.includes(type));
+
+  return {
+    meeting: resourcesByType(TYPES.meeting).at(0),
+    agenda: resourcesByType(TYPES.agenda).at(0),
+    agendaitems: resourcesByType(TYPES.agendaitem),
+    subcase: resourcesByType(TYPES.subcase).at(0),
+    submissionActivities: resourcesByType(TYPES.submissionActivity),
+    signFlows: resourcesByType(TYPES.signFlow),
+  };
+}
+
+async function getRelatedData(meetingId, subcaseUri) {
+  const queryString = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+PREFIX schema: <http://schema.org/>
+
+CONSTRUCT {
+  ?meeting a ?meetingType ;
+    mu:uuid ?meetingId ;
+    besluit:geplandeStart ?plannedStart ;
+    ext:secretarisVoorVergadering ?secretary .
+  ?agenda a ?agendaType ;
+    besluitvorming:isAgendaVoor ?meeting .
+
+  ?subcase a ?subcaseType ;
+    dct:alternative ?shortTitle ;
+    ext:agendapuntType ?agendaItemType ;
+    dct:title ?title ;
+    ext:heeftBevoegde ?mandatee ;
+    ext:bevatReedsBezorgdeDocumentVersie ?linkedPiece .
+
+  ?submissionActivity ext:indieningVindtPlaatsTijdens ?subcase ;
+    prov:generated ?piece ;
+    a ?submissionActivityType .
+
+  ?agendaActivity prov:wasInformedBy ?submissionActivity .
+
+  ?signFlow a ?signFlowType ;
+    sign:heeftBeslissing ?decisionActivity .
+  ?agendaitem a ?_agendaitemType ;
+    schema:position ?agendaitemNumber .
+}
+WHERE {
+  VALUES (?meetingId ?subcase)
+  {
+    (${sparqlEscapeString(meetingId)} ${sparqlEscapeUri(subcaseUri)})
+  }
+  ?meeting a ?meetingType ;
+           mu:uuid ?meetingId ;
+           besluit:geplandeStart ?plannedStart ;
+           ^besluitvorming:isAgendaVoor ?agenda ;
+            ext:secretarisVoorVergadering ?secretary .
+  FILTER NOT EXISTS { ?newerAgenda prov:wasRevisionOf ?agenda }
+  ?agenda a ?agendaType .
+
+  ?subcase a ?subcaseType ;
+           dct:alternative ?shortTitle ;
+           ext:agendapuntType ?agendaItemType .
+  OPTIONAL { ?subcase dct:title ?title }
+  OPTIONAL { ?subcase ext:heeftBevoegde ?mandatee }
+  OPTIONAL { ?subcase ext:bevatReedsBezorgdeDocumentversie ?linkedPiece }
+  OPTIONAL {
+    ?submissionActivity ext:indieningVindtPlaatsTijdens ?subcase ;
+                        a ?submissionActivityType .
+    ?submissionActivity prov:generated ?piece .
+    OPTIONAL { ?agendaActivity prov:wasInformedBy ?submissionActivity }
+    OPTIONAL {
+      ?signMarkingActivity sign:gemarkeerdStuk ?piece ;
+        sign:markeringVindtPlaatsTijdens ?signSubcase .
+      ?signFlow a ?signFlowType ;
+        sign:doorlooptHandtekening ?signSubcase ;
+        sign:heeftBeslissing ?decisionActivity .
+    }
+  }
+  OPTIONAL {
+    ?agenda dct:hasPart ?agendaitem .
+    ?agendaitem a ?_agendaitemType ;
+      dct:type ?agendaItemType ;
+      schema:position ?agendaitemNumber .
+  }
+}`;
+
+  return await query(queryString);
+}
+
+export {
+  getRelatedResources,
+}

--- a/lib/data-fetching.js
+++ b/lib/data-fetching.js
@@ -5,6 +5,7 @@ import { TYPES } from '../constants';
 async function getRelatedResources(meetingId, subcaseUri) {
   const response = await getRelatedData(meetingId, subcaseUri);
   const triples = responseToTriples(response);
+  // all predicates without ^ should be listed here
   const resources = triplesToResources(triples, {
     'http://www.w3.org/1999/02/22-rdf-syntax-ns#type': 'a',
     'http://www.w3.org/ns/prov#generated': 'pieces',
@@ -68,7 +69,7 @@ CONSTRUCT {
 
   ?signFlow a ?signFlowType ;
     sign:heeftBeslissing ?decisionActivity .
-  ?agendaitem a ?_agendaitemType ;
+  ?agendaitem a ?agendaitemClass ;
     schema:position ?agendaitemNumber .
 }
 WHERE {
@@ -105,7 +106,7 @@ WHERE {
   }
   OPTIONAL {
     ?agenda dct:hasPart ?agendaitem .
-    ?agendaitem a ?_agendaitemType ;
+    ?agendaitem a ?agendaitemClass ;
       dct:type ?agendaItemType ;
       schema:position ?agendaitemNumber .
   }

--- a/lib/data-fetching.js
+++ b/lib/data-fetching.js
@@ -79,8 +79,8 @@ WHERE {
   ?meeting a ?meetingType ;
            mu:uuid ?meetingId ;
            besluit:geplandeStart ?plannedStart ;
-           ^besluitvorming:isAgendaVoor ?agenda ;
-            ext:secretarisVoorVergadering ?secretary .
+           ^besluitvorming:isAgendaVoor ?agenda .
+  OPTIONAL { ?meeting ext:secretarisVoorVergadering ?secretary }
   FILTER NOT EXISTS { ?newerAgenda prov:wasRevisionOf ?agenda }
   ?agenda a ?agendaType .
 

--- a/lib/data-persisting.js
+++ b/lib/data-persisting.js
@@ -1,0 +1,108 @@
+import {
+  update,
+  sparqlEscapeUri,
+  sparqlEscapeString,
+  sparqlEscapeDateTime,
+  sparqlEscapeInt,
+  sparqlEscapeBool,
+} from 'mu';
+
+import { TYPES } from '../constants';
+
+async function persistRecords({
+  agenda,
+  signFlows,
+  newSubmission,
+  newsItem,
+  agendaActivity,
+  decisionActivity,
+  treatment,
+  agendaitem
+}) {
+  let queryString = `PREFIX schema: <http://schema.org/>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+DELETE {
+  ${sparqlEscapeUri(agenda.uri)} dct:modified ?oldModified .
+  ${signFlows.length ? signFlows.map((signFlow) => {
+    return `${sparqlEscapeUri(signFlow.uri)} sign:heeftBeslissing ${sparqlEscapeUri(signFlow.decisionActivity.at(0))} .`
+  }).join('  \n') : ''}
+} INSERT {
+  ${sparqlEscapeUri(agendaActivity.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.agendaActivity)} ;
+    mu:uuid ${sparqlEscapeString(agendaActivity.id)} ;
+    dossier:startDatum ${sparqlEscapeDateTime(agendaActivity.startDate)} ;
+    besluitvorming:vindtPlaatsTijdens ${sparqlEscapeUri(agendaActivity.subcase)} ;
+    prov:wasInformedBy ${agendaActivity.submissionActivities.map((a) => sparqlEscapeUri(a.uri)).join(', ')} .
+
+  ${sparqlEscapeUri(decisionActivity.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.decisionActivity)} ;
+    mu:uuid ${sparqlEscapeString(decisionActivity.id)} ;
+    ${decisionActivity.secretary ? `prov:wasAssociatedWith ${sparqlEscapeUri(decisionActivity.secretary)} ;` : ''}
+    ${decisionActivity.decisionResultCode ? `besluitvorming:resultaat ${sparqlEscapeUri(decisionActivity.decisionResultCode)} ;` : ''}
+    dossier:Activiteit.startdatum ${sparqlEscapeDateTime(decisionActivity.startDate)} ;
+    ext:beslissingVindtPlaatsTijdens ${sparqlEscapeUri(decisionActivity.subcase)} .
+
+  ${sparqlEscapeUri(treatment.uri)} a ${sparqlEscapeUri(TYPES.treatment)} ;
+    mu:uuid ${sparqlEscapeString(treatment.id)} ;
+    dct:created ${sparqlEscapeDateTime(treatment.created)} ;
+    dct:modified ${sparqlEscapeDateTime(treatment.modified)} ;
+    besluitvorming:heeftBeslissing ${sparqlEscapeUri(treatment.decisionActivity)} .
+
+  ${sparqlEscapeUri(agendaitem.uri)} a ${sparqlEscapeUri(TYPES.agendaitem)} ;
+    mu:uuid ${sparqlEscapeString(agendaitem.id)} ;
+    dct:created ${sparqlEscapeDateTime(agendaitem.created)} ;
+    schema:position ${sparqlEscapeInt(agendaitem.number)} ;
+    besluitvorming:korteTitel ${sparqlEscapeString(agendaitem.shortTitle)} ;
+    ${agendaitem.title ? `dct:title ${sparqlEscapeString(agendaitem.title)} ;` : ''}
+    ext:formeelOK ${sparqlEscapeUri(agendaitem.formallyOK)} ;
+    ${agendaitem.mandatees?.length ? `ext:heeftBevoegdeVoorAgendapunt ${agendaitem.mandatees.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ${agendaitem.pieces?.length ? `besluitvorming:geagendeerdStuk ${agendaitem.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ${agendaitem.linkedPieces?.length ? `ext:bevatReedsBezorgdAgendapuntDocumentversie ${agendaitem.linkedPieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    dct:type ${sparqlEscapeUri(agendaitem.agendaitemType)} .
+
+  ${sparqlEscapeUri(agendaitem.treatment)} dct:subject ${sparqlEscapeUri(agendaitem.uri)} .
+  ${sparqlEscapeUri(agendaitem.agendaActivity)} besluitvorming:genereertAgendapunt ${sparqlEscapeUri(agendaitem.uri)} .
+  ${sparqlEscapeUri(agendaitem.agenda)} dct:hasPart ${sparqlEscapeUri(agendaitem.uri)} .`;
+
+  if (newSubmission) {
+    queryString += `
+  ${sparqlEscapeUri(newSubmission.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.submissionActivity)} ;
+    mu:uuid ${sparqlEscapeString(newSubmission.id)} ;
+    dossier:Activiteit.startdatum ${sparqlEscapeDateTime(newSubmission.startDate)} ;
+    ${newSubmission.pieces?.length ? `prov:generated ${newSubmission.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ext:indieningVindtPlaatsTijdens ${sparqlEscapeUri(newSubmission.subcase)} .`;
+  }
+
+  if (newsItem) {
+    queryString += `
+  ${sparqlEscapeUri(newsItem.uri)} a ${sparqlEscapeUri(TYPES.newsItem)} ;
+    mu:uuid ${sparqlEscapeString(newsItem.id)} ;
+    prov:wasDerivedFrom ${sparqlEscapeUri(newsItem.treatment)} ;
+    dct:title ${sparqlEscapeString(newsItem.title)} ;
+    ${newsItem.htmlContent ? `nie:htmlContent ${sparqlEscapeString(newsItem.htmlContent)} ;` : ''}
+    ext:afgewerkt ${sparqlEscapeBool(newsItem.finished)} ;
+    ext:inNieuwsbrief ${sparqlEscapeBool(newsItem.inNewsletter)} .`;
+  }
+
+  queryString += `
+  ${sparqlEscapeUri(agenda.uri)} dct:modified ${sparqlEscapeDateTime(new Date())} .
+  ${signFlows.length ? signFlows.map((signFlow) => {
+    return `${sparqlEscapeUri(signFlow.uri)} sign:heeftBeslissing ${sparqlEscapeUri(decisionActivity.uri)} .`
+  }).join('  \n') : ''}
+} WHERE {
+  ${sparqlEscapeUri(agenda.uri)} dct:modified ?oldModified .
+}`;
+
+  await update(queryString);
+}
+
+export {
+  persistRecords,
+}

--- a/lib/data-persisting.js
+++ b/lib/data-persisting.js
@@ -61,7 +61,7 @@ DELETE {
     schema:position ${sparqlEscapeInt(agendaitem.number)} ;
     besluitvorming:korteTitel ${sparqlEscapeString(agendaitem.shortTitle)} ;
     ${agendaitem.title ? `dct:title ${sparqlEscapeString(agendaitem.title)} ;` : ''}
-    ext:formeelOK ${sparqlEscapeUri(agendaitem.formallyOK)} ;
+    ext:formeelOK ${sparqlEscapeUri(agendaitem.formallyOk)} ;
     ${agendaitem.mandatees?.length ? `ext:heeftBevoegdeVoorAgendapunt ${agendaitem.mandatees.map(sparqlEscapeUri).join(', ')} ;` : ''}
     ${agendaitem.pieces?.length ? `besluitvorming:geagendeerdStuk ${agendaitem.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
     ${agendaitem.linkedPieces?.length ? `ext:bevatReedsBezorgdAgendapuntDocumentversie ${agendaitem.linkedPieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
@@ -70,6 +70,11 @@ DELETE {
   ${sparqlEscapeUri(agendaitem.treatment)} dct:subject ${sparqlEscapeUri(agendaitem.uri)} .
   ${sparqlEscapeUri(agendaitem.agendaActivity)} besluitvorming:genereertAgendapunt ${sparqlEscapeUri(agendaitem.uri)} .
   ${sparqlEscapeUri(agendaitem.agenda)} dct:hasPart ${sparqlEscapeUri(agendaitem.uri)} .`;
+
+  if (agendaitem.privateComment) {
+    queryString += `
+  ${sparqlEscapeUri(agendaitem.uri)} ext:privateComment ${sparqlEscapeString(agendaitem.privateComment)} .`;
+  }
 
   if (newSubmission) {
     queryString += `

--- a/lib/meeting.js
+++ b/lib/meeting.js
@@ -1,0 +1,20 @@
+import { query, sparqlEscapeString } from 'mu';
+
+async function isMeetingClosed(meetingId) {
+  const queryString = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+
+ASK
+WHERE {
+  VALUES ?meetingId {
+    ${sparqlEscapeString(meetingId)}
+  }
+
+  ?meeting mu:uuid ?meetingId ;
+    besluitvorming:behandelt ?agenda .
+}`;
+  const response = await query(queryString);
+  return response.boolean;
+}
+
+export { isMeetingClosed }

--- a/lib/subcase.js
+++ b/lib/subcase.js
@@ -1,0 +1,35 @@
+import { query, sparqlEscapeUri } from 'mu';
+import { CONCEPTS } from '../constants';
+
+async function isSubcaseOnAgenda(subcaseUri) {
+  const queryString = `PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+
+ASK
+WHERE {
+  VALUES ?subcase {
+    ${sparqlEscapeUri(subcaseUri)}
+  }
+  VALUES ?postponed {
+    ${sparqlEscapeUri(CONCEPTS.DECISION_RESULT_CODES.POSTPONED)}
+  }
+
+  ?agendaActivity besluitvorming:vindtPlaatsTijdens ?subcase ;
+                  besluitvorming:genereertAgendapunt ?agendaitem .
+  ?agenda dct:hasPart ?agendaitem .
+  ?agenda besluitvorming:isAgendaVoor ?meeting .
+  ?treatment dct:subject ?agendaitem ;
+             besluitvorming:heeftBeslissing ?decisionActivity .
+  FILTER NOT EXISTS {
+    ?decisionActivity besluitvorming:resultaat ?postponed .
+    ?internalDecisionPublicationActivityUsed ext:internalDecisionPublicationActivityUsed ?meeting ;
+                                             prov:startedAtTime ?startTime .
+  }
+}`;
+  const response = await query(queryString);
+  return response.boolean;
+}
+
+export { isSubcaseOnAgenda }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,7 @@ function arrayEquals(a, b) {
     && a.every((element, index) => element === b[index]);
 }
 
-function triplesToResources(response, predicateMapping={}) {
+function responseToTriples(response) {
   const { head, results } = response;
   if (!arrayEquals(head.vars, ['s', 'p', 'o'])) {
     console.warn(
@@ -16,7 +16,11 @@ function triplesToResources(response, predicateMapping={}) {
     return [];
   }
 
-  return Array.from(results.bindings.reduce(
+  return results.bindings;
+}
+
+function triplesToResources(triples, predicateMapping={}) {
+  return Array.from(triples.reduce(
     (resources, triple) => {
       const { s: { value: s }, p: { value: p }, o: { value: o } } = triple;
 
@@ -76,6 +80,7 @@ function resourceToTriples(resource) {
 }
 
 export {
+  responseToTriples,
   triplesToResources,
   resourceToTriples,
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,12 @@ function responseToTriples(response) {
   return results.bindings;
 }
 
+/**
+ * Maps all incoming triples to ?s ?p ?o where ?s is alwasy the uri, ?o can be uri or value
+ * @param {*} triples 
+ * @param {*} predicateMapping all predicates to the right
+ * @returns 
+ */
 function triplesToResources(triples, predicateMapping={}) {
   return Array.from(triples.reduce(
     (resources, triple) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,81 @@
+import { sparqlEscape } from 'mu';
+
+function arrayEquals(a, b) {
+  return Array.isArray(a) && Array.isArray(b)
+    && a.length === b.length
+    && a.every((element, index) => element === b[index]);
+}
+
+function triplesToResources(response, predicateMapping={}) {
+  const { head, results } = response;
+  if (!arrayEquals(head.vars, ['s', 'p', 'o'])) {
+    console.warn(
+      'Expected a response containing triples as returned from a CONSTRUCT query, got following variables instead:',
+      head.vars
+    );
+    return [];
+  }
+
+  return Array.from(results.bindings.reduce(
+    (resources, triple) => {
+      const { s: { value: s }, p: { value: p }, o: { value: o } } = triple;
+
+      // First handle the forward predicate, without a ^,
+      // In which case we use s as the resource. If a mapping
+      // is encountered, it will be used, otherwise the bare
+      // predicate is used
+      let mappedP = predicateMapping[p] ?? p;
+      if (mappedP) {
+        const resource = resources.get(s) ?? {};
+        resource.uri = s;
+        if (Object.hasOwn(resource, mappedP)) {
+            resource[mappedP].push(o);
+        } else {
+            resource[mappedP] = [o];
+        }
+        resources.set(s, resource);
+      }
+
+      // Now handle the inverse predicate, with a ^,
+      // and use o as the resource
+      mappedP = predicateMapping[`^${p}`];
+      if (mappedP) {
+        const resource = resources.get(o) ?? {};
+        resource.uri = o;
+        if (Object.hasOwn(resource, mappedP)) {
+            resource[mappedP].push(s);
+        } else {
+            resource[mappedP] = [s];
+        }
+        resources.set(o, resource);
+      }
+
+      return resources;
+    },
+    new Map(),
+  ).values());
+}
+
+function resourceToTriples(resource) {
+  const { uri, incoming, outgoing } = resource;
+  const triples = [];
+  for (const [p, o] of Object.entries(outgoing)) {
+    if (Array.isArray(o)) {
+      for (const obj of o) {
+        triples.push([sparqlEscape(uri, 'uri'), sparqlEscape(p, 'uri'), sparqlEscape(obj.value, obj.type)]);
+      }
+    } else {
+      triples.push([sparqlEscape(uri, 'uri'), sparqlEscape(p, 'uri'), sparqlEscape(o.value, o.type)]);
+    }
+  }
+  for (const [p, s] of Object.entries(incoming)) {
+    triples.push([sparqlEscape(s, 'uri'), sparqlEscape(p, 'uri'), sparqlEscape(uri, 'uri')]);
+  }
+
+  return triples;
+}
+
+export {
+  triplesToResources,
+  resourceToTriples,
+}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4315

This moves all the logic contained in the frontend for creating new agendaitems based on subcases to this new service.

The service does some basic checking to ensure that the provided meeting and subcase are valid (meeting must not be closed, subcase must not already be submitted) and then handles all creation of resources by itself.

Before returning we sleep for 4 seconds, that's the minimum I found to reliably beat the cache in the frontend. In an ideal world we spend a little more time on this implementation and pass back all the records we have created in the response and then pick them up in the frontend so that there's no need to beat the cache.