### PR TITLE
KAS-4608: Automatically order agendaitems

### DIFF
--- a/app.js
+++ b/app.js
@@ -173,7 +173,9 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
       signFlows,
     });
 
-    await reorderAgendaitems(agenda.uri, agendaitem.agendaitemType);
+    if (agendaitem.agendaitemType !== CONCEPTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT) {
+      await reorderAgendaitems(agenda.uri, agendaitem.agendaitemType);
+    }
 
     /**
     * Pipe dream: instead of sleeping and responding with one thing, we should

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ import { isMeetingClosed } from './lib/meeting';
 import { isSubcaseOnAgenda } from './lib/subcase';
 import { getRelatedResources } from './lib/data-fetching';
 import { persistRecords } from './lib/data-persisting';
+import { reorderAgendaitems } from './lib/agendaitem-order';
 
 const cacheClearTimeout = process.env.CACHE_CLEAR_TIMEOUT || 5000;
 
@@ -171,6 +172,8 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
       agenda,
       signFlows,
     });
+
+    await reorderAgendaitems(agenda.uri, agendaitem.agendaitemType);
 
     /**
     * Pipe dream: instead of sleeping and responding with one thing, we should

--- a/lib/agendaitem-order.js
+++ b/lib/agendaitem-order.js
@@ -3,11 +3,8 @@ import { reduceResultSet } from './utils';
 
 async function getRelatedAgendaitems(agenda, agendaitemType) {
   const lastApprovedPositionQuery = `PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX schema: <http://schema.org/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
 SELECT ?agendaitemPosition
 WHERE {

--- a/lib/agendaitem-order.js
+++ b/lib/agendaitem-order.js
@@ -80,7 +80,7 @@ async function reorderAgendaitems(agenda, agendaitemType) {
       toBeUpdatedAgendaitems.push({
         uri,
         oldPosition: agendaitemPosition,
-        newPosition: expectedAgendaitemPosition
+        newPosition: expectedAgendaitemPosition,
       });
     }
   }
@@ -88,7 +88,6 @@ async function reorderAgendaitems(agenda, agendaitemType) {
     await applyAgendaitemsOrder(toBeUpdatedAgendaitems);
   }
 }
-
 
 /* We sort on the mandatee priority. To do this, we simply cast the array of
  * priorities to a string: [1, 2, 3] → "1,2,3" and we just use string
@@ -98,6 +97,7 @@ async function reorderAgendaitems(agenda, agendaitemType) {
  * If multiple items have the same priority list, we sort them based on their
  * existing position. This way manual reorders inside a priority group are
  * kept when submitting a new agendaitem.
+ * If no priorities are found we set it to "99" to order them last
  */
 function sortAgendaitems(agendaitems) {
   return agendaitems.sort((a1, a2) => {
@@ -109,14 +109,14 @@ function sortAgendaitems(agendaitems) {
     } else if (a1.mandateePriority) {
       priority1 = [a1.mandateePriority.toString()];
     } else {
-      priority1 = ["99"]
+      priority1 = ["99"];
     }
     if (Array.isArray(a2.mandateePriority)) {
       priority2 = a2.mandateePriority.map((p) => p.toString());
     } else if (a2.mandateePriority) {
       priority2 = [a2.mandateePriority.toString()];
     } else {
-      priority2 = ["99"]
+      priority2 = ["99"];
     }
     [...priority1, ...priority2].forEach((p) => numberLength = Math.max(numberLength, p.length));
 

--- a/lib/agendaitem-order.js
+++ b/lib/agendaitem-order.js
@@ -106,13 +106,17 @@ function sortAgendaitems(agendaitems) {
 
     if (Array.isArray(a1.mandateePriority)) {
       priority1 = a1.mandateePriority.map((p) => p.toString());
-    } else {
+    } else if (a1.mandateePriority) {
       priority1 = [a1.mandateePriority.toString()];
+    } else {
+      priority1 = ["99"]
     }
     if (Array.isArray(a2.mandateePriority)) {
       priority2 = a2.mandateePriority.map((p) => p.toString());
-    } else {
+    } else if (a2.mandateePriority) {
       priority2 = [a2.mandateePriority.toString()];
+    } else {
+      priority2 = ["99"]
     }
     [...priority1, ...priority2].forEach((p) => numberLength = Math.max(numberLength, p.length));
 

--- a/lib/agendaitem-order.js
+++ b/lib/agendaitem-order.js
@@ -52,25 +52,7 @@ WHERE {
 async function reorderAgendaitems(agenda, agendaitemType) {
   const agendaitems = reduceResultSet(await getRelatedAgendaitems(agenda, agendaitemType));
 
-  // We sort on the mandatee priority. To do this, we simply cast the array of
-  // priorities to a string: [1, 2, 3] → "1,2,3" and we just use string
-  // comparisons to ensure we have a lexicographical sort. E.g. given the
-  // following list of priorities: [ [1, 2], [1], [2, 4], [3], [2, 3] ]
-  // the sorted list will be: [ [1], [1, 2], [2, 3], [2, 4], [3] ]
-  //
-  // If multiple items have the same priority list, we sort them based on their
-  // existing position. This way manual reorders inside a priority group are
-  // kept when submitting a new agendaitem.
-  const sortedAgendaitems = agendaitems.sort(
-    (a1, a2) => {
-      const priority1 = Array.isArray(a1.mandateePriority) ? a1.mandateePriority.sort().toString() : String(a1.mandateePriority);
-      const priority2 = Array.isArray(a2.mandateePriority) ? a2.mandateePriority.sort().toString() : String(a2.mandateePriority);
-      return priority1 === priority2
-        ? a1.agendaitemPosition - a2.agendaitemPosition
-        : priority1 < priority2
-          ? -1
-          : 1
-    });
+  const sortedAgendaitems = sortAgendaitems(agendaitems);
 
   const lowestAgendaitemPosition = Math.min(...agendaitems.map((a) => parseInt(a.agendaitemPosition)));
   const toBeUpdatedAgendaitems = [];
@@ -88,6 +70,44 @@ async function reorderAgendaitems(agenda, agendaitemType) {
   if (toBeUpdatedAgendaitems.length) {
     await applyAgendaitemsOrder(toBeUpdatedAgendaitems);
   }
+}
+
+
+/* We sort on the mandatee priority. To do this, we simply cast the array of
+ * priorities to a string: [1, 2, 3] → "1,2,3" and we just use string
+ * comparisons to ensure we have a lexicographical sort. E.g. given the
+ * following list of priorities: [ [1, 2], [1], [2, 4], [3], [2, 3] ]
+ * the sorted list will be: [ [1], [1, 2], [2, 3], [2, 4], [3] ]
+ * If multiple items have the same priority list, we sort them based on their
+ * existing position. This way manual reorders inside a priority group are
+ * kept when submitting a new agendaitem.
+ */
+function sortAgendaitems(agendaitems) {
+  return agendaitems.sort((a1, a2) => {
+    let priority1, priority2;
+    let numberLength = 0;
+
+    if (Array.isArray(a1.mandateePriority)) {
+      priority1 = a1.mandateePriority.sort().map((p) => p.toString());
+    } else {
+      priority1 = [a1.mandateePriority.toString()];
+    }
+    if (Array.isArray(a2.mandateePriority)) {
+      priority2 = a2.mandateePriority.sort().map((p) => p.toString());
+    } else {
+      priority2 = [a2.mandateePriority.toString()];
+    }
+    [...priority1, ...priority2].forEach((p) => numberLength = Math.max(numberLength, p.length));
+
+    priority1 = priority1.map((p) => p.padStart(numberLength, '0'));
+    priority2 = priority2.map((p) => p.padStart(numberLength, '0'));
+
+    return priority1 === priority2
+      ? a1.agendaitemPosition - a2.agendaitemPosition
+      : priority1 < priority2
+        ? -1
+        : 1
+  });
 }
 
 export {

--- a/lib/agendaitem-order.js
+++ b/lib/agendaitem-order.js
@@ -88,19 +88,22 @@ function sortAgendaitems(agendaitems) {
     let numberLength = 0;
 
     if (Array.isArray(a1.mandateePriority)) {
-      priority1 = a1.mandateePriority.sort().map((p) => p.toString());
+      priority1 = a1.mandateePriority.map((p) => p.toString());
     } else {
       priority1 = [a1.mandateePriority.toString()];
     }
     if (Array.isArray(a2.mandateePriority)) {
-      priority2 = a2.mandateePriority.sort().map((p) => p.toString());
+      priority2 = a2.mandateePriority.map((p) => p.toString());
     } else {
       priority2 = [a2.mandateePriority.toString()];
     }
     [...priority1, ...priority2].forEach((p) => numberLength = Math.max(numberLength, p.length));
 
-    priority1 = priority1.map((p) => p.padStart(numberLength, '0'));
-    priority2 = priority2.map((p) => p.padStart(numberLength, '0'));
+    priority1 = priority1.map((p) => p.padStart(numberLength, '0')).sort();
+    priority2 = priority2.map((p) => p.padStart(numberLength, '0')).sort();
+
+    console.debug(priority1);
+    console.debug(priority2);
 
     return priority1 === priority2
       ? a1.agendaitemPosition - a2.agendaitemPosition

--- a/lib/agendaitem-order.js
+++ b/lib/agendaitem-order.js
@@ -102,9 +102,6 @@ function sortAgendaitems(agendaitems) {
     priority1 = priority1.map((p) => p.padStart(numberLength, '0')).sort();
     priority2 = priority2.map((p) => p.padStart(numberLength, '0')).sort();
 
-    console.debug(priority1);
-    console.debug(priority2);
-
     return priority1 === priority2
       ? a1.agendaitemPosition - a2.agendaitemPosition
       : priority1 < priority2

--- a/lib/agendaitem-order.js
+++ b/lib/agendaitem-order.js
@@ -1,0 +1,87 @@
+import { query, update, sparqlEscapeUri, sparqlEscapeInt } from 'mu';
+import { reduceResultSet } from './utils';
+
+async function getRelatedAgendaitems(agenda, agendaitemType) {
+  const queryString = `PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX schema: <http://schema.org/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT DISTINCT ?agendaitem ?agendaitemCreated ?agendaitemPosition ?mandateePriority
+WHERE {
+  ${sparqlEscapeUri(agenda)} dct:hasPart ?agendaitem .
+  ?agendaitem schema:position ?agendaitemPosition ;
+              dct:created ?agendaitemCreated ;
+              dct:type ${sparqlEscapeUri(agendaitemType)} .
+  FILTER NOT EXISTS {
+    ?agendaitem prov:wasRevisionOf ?olderAgendaitem .
+  }
+  ?agendaActivity besluitvorming:genereertAgendapunt ?agendaitem ;
+    besluitvorming:vindtPlaatsTijdens ?subcase .
+  OPTIONAL {
+    ?subcase ext:heeftBevoegde ?mandatee .
+    ?mandatee mandaat:rangorde ?mandateePriority .
+  }
+}`;
+  return await query(queryString);
+}
+
+async function applyAgendaitemsOrder(orders) {
+  const queryString = `PREFIX schema: <http://schema.org/>
+
+DELETE {
+  ?agendaitem schema:position ?oldPosition .
+}
+INSERT {
+  ?agendaitem schema:position ?newPosition .
+}
+WHERE {
+  VALUES (?agendaitem ?oldPosition ?newPosition) {
+    ${orders
+      .map(
+        ({ uri, oldPosition, newPosition }) =>
+          `(${sparqlEscapeUri(uri)} ${sparqlEscapeInt(oldPosition)} ${sparqlEscapeInt(newPosition)})`)
+      .join('\n    ')}
+  }
+}`;
+  await update(queryString);
+}
+
+async function reorderAgendaitems(agenda, agendaitemType) {
+  const agendaitems = reduceResultSet(await getRelatedAgendaitems(agenda, agendaitemType));
+
+  const sortedAgendaitems = agendaitems.sort(
+    (a1, a2) => {
+      const priority1 = Array.isArray(a1.mandateePriority) ? a1.mandateePriority.sort().toString() : String(a1.mandateePriority);
+      const priority2 = Array.isArray(a2.mandateePriority) ? a2.mandateePriority.sort().toString() : String(a2.mandateePriority);
+      return priority1 === priority2
+        // ? a1.agendaitemCreated.getTime() - a2.agendaitemCreated.getTime()
+        ? a1.agendaitemPosition - a2.agendaitemPosition
+        : priority1 < priority2
+          ? -1
+          : 1
+    });
+
+  const lowestAgendaitemPosition = Math.min(...agendaitems.map((a) => parseInt(a.agendaitemPosition)));
+  const toBeUpdatedAgendaitems = [];
+  for (let i = 0; i < sortedAgendaitems.length; i++) {
+    const { uri, agendaitemPosition } = sortedAgendaitems[i];
+    const expectedAgendaitemPosition = lowestAgendaitemPosition + i;
+    if (agendaitemPosition !== expectedAgendaitemPosition) {
+      toBeUpdatedAgendaitems.push({
+        uri,
+        oldPosition: agendaitemPosition,
+        newPosition: expectedAgendaitemPosition
+      });
+    }
+  }
+  if (toBeUpdatedAgendaitems.length) {
+    await applyAgendaitemsOrder(toBeUpdatedAgendaitems);
+  }
+}
+
+export {
+  reorderAgendaitems,
+}

--- a/lib/agendaitem-order.js
+++ b/lib/agendaitem-order.js
@@ -2,6 +2,25 @@ import { query, update, sparqlEscapeUri, sparqlEscapeInt } from 'mu';
 import { reduceResultSet } from './utils';
 
 async function getRelatedAgendaitems(agenda, agendaitemType) {
+  const lastApprovedPositionQuery = `PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX schema: <http://schema.org/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT ?agendaitemPosition
+WHERE {
+  ${sparqlEscapeUri(agenda)} dct:hasPart ?agendaitem .
+  ?agendaitem schema:position ?agendaitemPosition ;
+              prov:wasRevisionOf ?olderAgendaitem ;
+              dct:type ${sparqlEscapeUri(agendaitemType)} .
+} ORDER BY DESC(?agendaitemPosition) LIMIT 1`;
+  const data = await query(lastApprovedPositionQuery);
+  let lastApprovedPosition = 0;
+  if (data?.results?.bindings && data.results.bindings.length) {
+    lastApprovedPosition = +data.results.bindings[0].agendaitemPosition.value;
+  }
   const queryString = `PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX schema: <http://schema.org/>
@@ -24,6 +43,7 @@ WHERE {
     ?subcase ext:heeftBevoegde ?mandatee .
     ?mandatee mandaat:rangorde ?mandateePriority .
   }
+  ${lastApprovedPosition ? `FILTER ( ?agendaitemPosition > ${lastApprovedPosition} )` : ''}
 }`;
   return await query(queryString);
 }
@@ -99,9 +119,8 @@ function sortAgendaitems(agendaitems) {
     }
     [...priority1, ...priority2].forEach((p) => numberLength = Math.max(numberLength, p.length));
 
-    priority1 = priority1.map((p) => p.padStart(numberLength, '0')).sort();
-    priority2 = priority2.map((p) => p.padStart(numberLength, '0')).sort();
-
+    priority1 = priority1.map((p) => p.padStart(numberLength, '0')).sort().toString();
+    priority2 = priority2.map((p) => p.padStart(numberLength, '0')).sort().toString();
     return priority1 === priority2
       ? a1.agendaitemPosition - a2.agendaitemPosition
       : priority1 < priority2

--- a/lib/agendaitem-order.js
+++ b/lib/agendaitem-order.js
@@ -52,12 +52,20 @@ WHERE {
 async function reorderAgendaitems(agenda, agendaitemType) {
   const agendaitems = reduceResultSet(await getRelatedAgendaitems(agenda, agendaitemType));
 
+  // We sort on the mandatee priority. To do this, we simply cast the array of
+  // priorities to a string: [1, 2, 3] → "1,2,3" and we just use string
+  // comparisons to ensure we have a lexicographical sort. E.g. given the
+  // following list of priorities: [ [1, 2], [1], [2, 4], [3], [2, 3] ]
+  // the sorted list will be: [ [1], [1, 2], [2, 3], [2, 4], [3] ]
+  //
+  // If multiple items have the same priority list, we sort them based on their
+  // existing position. This way manual reorders inside a priority group are
+  // kept when submitting a new agendaitem.
   const sortedAgendaitems = agendaitems.sort(
     (a1, a2) => {
       const priority1 = Array.isArray(a1.mandateePriority) ? a1.mandateePriority.sort().toString() : String(a1.mandateePriority);
       const priority2 = Array.isArray(a2.mandateePriority) ? a2.mandateePriority.sort().toString() : String(a2.mandateePriority);
       return priority1 === priority2
-        // ? a1.agendaitemCreated.getTime() - a2.agendaitemCreated.getTime()
         ? a1.agendaitemPosition - a2.agendaitemPosition
         : priority1 < priority2
           ? -1

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,11 +21,11 @@ function responseToTriples(response) {
 
 /**
  * Maps all incoming triples to ?s ?p ?o where ?s is alwasy the uri, ?o can be uri or value
- * @param {*} triples 
+ * @param {*} triples
  * @param {*} predicateMapping all predicates to the right
- * @returns 
+ * @returns
  */
-function triplesToResources(triples, predicateMapping={}) {
+function triplesToResources(triples, predicateMapping = {}) {
   return Array.from(triples.reduce(
     (resources, triple) => {
       const { s: { value: s }, p: { value: p }, o: { value: o } } = triple;
@@ -39,9 +39,9 @@ function triplesToResources(triples, predicateMapping={}) {
         const resource = resources.get(s) ?? {};
         resource.uri = s;
         if (Object.hasOwn(resource, mappedP)) {
-            resource[mappedP].push(o);
+          resource[mappedP].push(o);
         } else {
-            resource[mappedP] = [o];
+          resource[mappedP] = [o];
         }
         resources.set(s, resource);
       }
@@ -53,9 +53,9 @@ function triplesToResources(triples, predicateMapping={}) {
         const resource = resources.get(o) ?? {};
         resource.uri = o;
         if (Object.hasOwn(resource, mappedP)) {
-            resource[mappedP].push(s);
+          resource[mappedP].push(s);
         } else {
-            resource[mappedP] = [s];
+          resource[mappedP] = [s];
         }
         resources.set(o, resource);
       }
@@ -85,8 +85,88 @@ function resourceToTriples(resource) {
   return triples;
 }
 
+/**
+ * Reduce a result set to a set with a single entry per URI.
+ *
+ * A result set is in essence a table whose columns are the variables selected
+ * in a SELECT query and whose rows are the different matching combinations of
+ * variables. This function will collapse these rows on a URI basis, first by
+ * finding a variable to represent the URI of a resource (and if no such
+ * variable can be found, an error will be thrown), afterwards all other
+ * variables will be collapsed into one entry. If multiple rows in the original
+ * result set contain the same value for the same variable, subsequent entries
+ * are ignored. If multiple rows contain different variables, they're returned
+ * as an array by this function.
+ */
+function reduceResultSet(resultSet, uriVariable = undefined) {
+  const head = resultSet.head;
+  const bindings = resultSet.results.bindings;
+
+  if (bindings.length === 0) {
+    return null;
+  }
+
+  const uriVar = uriVariable ?? head.vars.at(0);
+
+  const resultMap = bindings.reduce((map, binding) => {
+    const uri = binding[uriVar].value;
+    const resource = map.get(uri) ?? {};
+
+
+    resource.uri = uri;
+    for (const variable of head.vars) {
+      const currentVar = binding[variable];
+      const previousVar = resource[variable];
+
+      if (previousVar === undefined) {
+        resource[variable] = currentVar;
+      } else if (Array.isArray(previousVar)) {
+        previousVar.push(currentVar);
+      } else if (previousVar.value !== currentVar.value) {
+        resource[variable] = [previousVar, currentVar];
+      }
+    }
+
+    map.set(uri, resource);
+    return map;
+  }, new Map());
+
+  const results = Array.from(resultMap.values());
+
+  const destructureVariable = (variable) => {
+    if (variable) {
+      try {
+        const { datatype, value } = variable;
+        if (datatype === 'http://www.w3.org/2001/XMLSchema#integer') {
+          return parseInt(value);
+        } else if (datatype === 'http://www.w3.org/2001/XMLSchema#dateTime') {
+          return new Date(value);
+        } else {
+          return value;
+        }
+      } catch {
+        return undefined;
+      }
+    }
+  };
+  return results.map((result) => {
+    for (const variable of head.vars) {
+      let currentVar = result[variable];
+      let parsed = undefined;
+      if (Array.isArray(currentVar)) {
+        parsed = currentVar.map(destructureVariable);
+      } else {
+        parsed = destructureVariable(currentVar);
+      }
+      result[variable] = parsed;
+    }
+    return result;
+  });
+}
+
 export {
   responseToTriples,
   triplesToResources,
   resourceToTriples,
+  reduceResultSet,
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4608

When submitting a subcase on an agenda, we now list all the agendaitems related to said specific agenda version (i.e. the latest ontwerp agenda of a meeting) and order them by mandatee priority.

Items without a mandatee (e.g. decreten) are sorted at the end of the list.

When a new agenda version is created, new items will not take into account the order of items of previous versions. I.e. new mandatee priority groups will be "made".