### PR TITLE
KAS-4690 add endpoint to query an unpropagated meeting of a submission

### DIFF
--- a/lib/meeting.js
+++ b/lib/meeting.js
@@ -74,8 +74,41 @@ ORDER BY DESC(?plannedStart)`;
   return openMeetings;
 }
 
+async function getMeetingForSubmission(submissionId) {
+  // subtract 1 week to counter submissions done the same day as the agenda
+  const queryString = `PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX subm: <http://mu.semte.ch/vocabularies/ext/submissions/>
+
+SELECT DISTINCT (?meeting AS ?uri) ?id ?serialnumber ?plannedStart ?type ?agendaId ?agenda
+WHERE {
+  ?submission a subm:Indiening ;
+              mu:uuid ${sparqlEscapeString(submissionId)} ;
+              subm:ingediendVoorVergadering ?meeting.
+  ?meeting a besluit:Vergaderactiviteit ;
+           mu:uuid ?id ;
+           besluit:geplandeStart ?plannedStart ;
+           dct:type ?kind .
+
+  ?agenda besluitvorming:isAgendaVoor ?meeting ;
+          besluitvorming:volgnummer ?serialnumber ;
+          mu:uuid ?agendaId .
+  ?kind skos:prefLabel ?type .
+  FILTER NOT EXISTS { ?newerAgenda prov:wasRevisionOf ?agenda }
+}
+`;
+  const response = await querySudo(queryString);
+  const meeting = reduceResultSet(response);
+  return meeting?.at(0);
+}
+
 export {
   isMeetingClosed,
   getOpenMeetings,
+  getMeetingForSubmission,
   submitSubmissionOnMeeting,
 }

--- a/lib/meeting.js
+++ b/lib/meeting.js
@@ -84,7 +84,7 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX subm: <http://mu.semte.ch/vocabularies/ext/submissions/>
 
-SELECT DISTINCT (?meeting AS ?uri) ?id ?serialnumber ?plannedStart ?type ?agendaId ?agenda
+SELECT DISTINCT (?meeting AS ?uri) ?id ?serialnumber ?plannedStart ?kind ?type ?agendaId ?agenda
 WHERE {
   ?submission a subm:Indiening ;
               mu:uuid ${sparqlEscapeString(submissionId)} ;


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4690

Needed a way to get more meeting data when not yet propagated without having to loop through open meetings and try to match on date or time of plannedStart (which does not work when PVV exists).