### PR TITLE
KAS-4733: Allow admins to resubmit retracted agendaitems

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -15,6 +15,7 @@ const TYPES = {
 const CONCEPTS = {
   DECISION_RESULT_CODES: {
     POSTPONED: 'http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/a29b3ffd-0839-45cb-b8f4-e1760f7aacaa',
+    RETRACTED: 'http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/453a36e8-6fbd-45d3-b800-ec96e59f273b',
     ACKNOWLEDGED: 'http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/9f342a88-9485-4a83-87d9-245ed4b504bf',
   },
   ACCEPTANCE_STATUSES: {

--- a/lib/subcase.js
+++ b/lib/subcase.js
@@ -15,6 +15,9 @@ WHERE {
   VALUES ?postponed {
     ${sparqlEscapeUri(CONCEPTS.DECISION_RESULT_CODES.POSTPONED)}
   }
+  VALUES ?retracted {
+    ${sparqlEscapeUri(CONCEPTS.DECISION_RESULT_CODES.RETRACTED)}
+  }
 
   ?agendaActivity besluitvorming:vindtPlaatsTijdens ?subcase ;
                   besluitvorming:genereertAgendapunt ?agendaitem .
@@ -26,6 +29,9 @@ WHERE {
     ?decisionActivity besluitvorming:resultaat ?postponed .
     ?internalDecisionPublicationActivityUsed ext:internalDecisionPublicationActivityUsed ?meeting ;
                                              prov:startedAtTime ?startTime .
+  }
+  FILTER NOT EXISTS {
+    ?decisionActivity besluitvorming:resultaat ?retracted .
   }
 }`;
   const response = await query(queryString);


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4733

Allows for agendaitems that have been retracted to be resubmitted.

Perhaps this could also use a permission check to ensure only admins can do this, but we never do these kinds of things in services (this isn't meant as an encouragement to continue not doing this, just an observation).