### PR TITLE
KAS-4890: Uitgestelde punten heragenderen met indieningen

### DIFF
--- a/app.js
+++ b/app.js
@@ -242,6 +242,7 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
       agendaActivity: agendaActivity.uri,
       treatment: treatment.uri,
       privateComment: privateComment,
+      isApproval: false,
     };
 
     let newsItem;

--- a/app.js
+++ b/app.js
@@ -71,9 +71,12 @@ app.get('/submissions/:id/for-meeting', async function(req, res, next) {
   }
 
   const meeting = await getMeetingForSubmission(submissionId);
-  return res.status(200).send({
-    data: { id: meeting.id, type: 'meetings', attributes: meeting }
-  });
+  if (meeting?.id) {
+    return res.status(200).send({
+      data: { id: meeting.id, type: 'meetings', attributes: meeting }
+    });
+  }
+  return next({ message: 'The submission is not submitted to any meeting, please contact the administrator', status: 404 }); 
 });
 
 app.post('/meetings/:id/submit-submission', async function(req, res, next) {

--- a/constants.js
+++ b/constants.js
@@ -45,9 +45,15 @@ const GRAPHS = {
   SUBMISSION: 'http://mu.semte.ch/graphs/system/submissions',
 }
 
+const ROLES = {
+  MINISTER: 'http://themis.vlaanderen.be/id/gebruikersrol/01ace9e0-f810-474e-b8e0-f578ff1e230d',
+  KABINET_DOSSIERBEHEERDER: 'http://themis.vlaanderen.be/id/gebruikersrol/6bcebe59-0cb5-4c5e-ab40-ca98b65887a4',
+}
+
 export {
   TYPES,
   CONCEPTS,
   URI_BASES,
   GRAPHS,
+  ROLES,
 }

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -68,8 +68,8 @@ WHERE {
 
   ?meeting mu:uuid ?meetingId ;
     dct:type ?kind ;
-    adms:identifier ?number ;
     besluit:geplandeStart ?plannedStart .
+  OPTIONAL { ?meeting adms:identifier ?number .}
 }
 ORDER BY DESC(?plannedStart)`;
 

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -39,6 +39,8 @@ WHERE {
 }
 
 async function getAgendasForSubcase(subcaseId, useSudo=false) {
+  // "prov:wasRevisionOf" predicate itself can be propagated already even if the newer agenda was not
+  // for other graphs we need to verify if that newer agenda exists or not f.e. by checking id
   const queryString = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
@@ -62,7 +64,7 @@ WHERE {
     mu:uuid ?agendaId ;
     besluitvorming:isAgendaVoor ?meeting ;
     besluitvorming:agendaStatus ?status .
-  FILTER NOT EXISTS { ?newer prov:wasRevisionOf ?agenda }
+  FILTER NOT EXISTS { ?newerId ^mu:uuid/prov:wasRevisionOf ?agenda }
 
   ?meeting mu:uuid ?meetingId ;
     dct:type ?kind ;

--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -1,5 +1,7 @@
 import { query, sparqlEscapeUri, sparqlEscapeString } from 'mu';
-import { CONCEPTS } from '../constants';
+import { CONCEPTS, GRAPHS } from '../constants';
+import { querySudo } from '@lblod/mu-auth-sudo';
+import { reduceResultSet } from './utils';
 
 async function isApprovedAgenda(agendaId) {
   const queryString = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -36,7 +38,50 @@ WHERE {
   return null;
 }
 
+async function getAgendasForSubcase(subcaseId, useSudo=false) {
+  const queryString = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+SELECT DISTINCT (?meeting AS ?uri) ?meetingId ?agendaId ?agendaitemId ?plannedStart ?status ?kind ?number
+${useSudo ? `FROM ${sparqlEscapeUri(GRAPHS.KANSELARIJ)}` : ''}
+WHERE {
+  ?subcase a dossier:Procedurestap ;
+    mu:uuid ${sparqlEscapeString(subcaseId)} ;
+    ^besluitvorming:vindtPlaatsTijdens ?agendaActivity .
+
+  ?agendaActivity besluitvorming:genereertAgendapunt ?agendaitem .
+  
+  ?agendaitem mu:uuid ?agendaitemId .
+
+  ?agenda dct:hasPart ?agendaitem ;
+    mu:uuid ?agendaId ;
+    besluitvorming:isAgendaVoor ?meeting ;
+    besluitvorming:agendaStatus ?status .
+  FILTER NOT EXISTS { ?newer prov:wasRevisionOf ?agenda }
+
+  ?meeting mu:uuid ?meetingId ;
+    dct:type ?kind ;
+    adms:identifier ?number ;
+    besluit:geplandeStart ?plannedStart .
+}
+ORDER BY DESC(?plannedStart)`;
+
+  const queryFunction = useSudo ? querySudo : query;
+  const response = await queryFunction(queryString);
+  const agendas = reduceResultSet(response);
+  if (agendas === null) {
+    return []
+  }
+  return agendas;
+}
+
 export {
   isApprovedAgenda,
   getAgenda,
+  getAgendasForSubcase,
 }

--- a/lib/data-persisting.js
+++ b/lib/data-persisting.js
@@ -70,6 +70,7 @@ DELETE {
     ${agendaitem.mandatees?.length ? `ext:heeftBevoegdeVoorAgendapunt ${agendaitem.mandatees.map(sparqlEscapeUri).join(', ')} ;` : ''}
     ${agendaitem.pieces?.length ? `besluitvorming:geagendeerdStuk ${agendaitem.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
     ${agendaitem.linkedPieces?.length ? `ext:bevatReedsBezorgdAgendapuntDocumentversie ${agendaitem.linkedPieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ext:isGoedkeuringVanDeNotulen ${sparqlEscapeBoolCustom(agendaitem.isApproval)} ;
     dct:type ${sparqlEscapeUri(agendaitem.agendaitemType)} .
 
   ${sparqlEscapeUri(agendaitem.treatment)} dct:subject ${sparqlEscapeUri(agendaitem.uri)} .

--- a/lib/session.js
+++ b/lib/session.js
@@ -10,4 +10,28 @@ ASK {
   return response.boolean;
 }
 
-export { isLoggedIn }
+async function sessionHasRole(sessionUri, roleUris) {
+  if (!roleUris || roleUris.length === 0)
+    return false;
+  
+  const queryString = `PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+ASK {
+  VALUES (?roleUri) {
+    ${roleUris.map(uri => `(${sparqlEscapeUri(uri)})`).join(`
+    `)}
+  }
+
+  ${sparqlEscapeUri(sessionUri)} session:account ?account ;
+    ext:sessionMembership / org:role ?roleUri .
+}`;
+  const response = await query(queryString);
+  return response.boolean;
+}
+
+export {
+  isLoggedIn,
+  sessionHasRole,
+}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4890

Adds an endpoint to fetch all agendas related to a subcase. For certain roles (minister & kabinetdossierbeheerder) we look at all agendas, also the ones in the Kanselarij graph.

The idea behind this endpoint is that the frontend can know if a subcase that has been postponed is already for submitted to a new agenda. This allows us to implement the feature that KDB can resubmit an item that has been postponed but not yet put on an agenda, and tell the secretary which agenda it should be put on.