### PR TITLE
KAS-4896 add agenda-activity and decision result to query

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -49,14 +49,17 @@ PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX adms: <http://www.w3.org/ns/adms#>
 
-SELECT DISTINCT (?meeting AS ?uri) ?meetingId ?agendaId ?agendaitemId ?plannedStart ?status ?kind ?number
+SELECT DISTINCT (?meeting AS ?uri) ?meetingId ?agendaId ?agendaitemId ?plannedStart ?status ?kind ?number ?decisionResultCode ?agendaActivityId ?agendaActivityStart
 ${useSudo ? `FROM ${sparqlEscapeUri(GRAPHS.KANSELARIJ)}` : ''}
 WHERE {
   ?subcase a dossier:Procedurestap ;
     mu:uuid ${sparqlEscapeString(subcaseId)} ;
     ^besluitvorming:vindtPlaatsTijdens ?agendaActivity .
 
-  ?agendaActivity besluitvorming:genereertAgendapunt ?agendaitem .
+  ?agendaActivity besluitvorming:genereertAgendapunt ?agendaitem ;
+    mu:uuid ?agendaActivityId ;
+    dossier:startDatum ?agendaActivityStart .
+  OPTIONAL { ?agendaitem ^dct:subject/besluitvorming:heeftBeslissing/besluitvorming:resultaat ?decisionResultCode . }
   
   ?agendaitem mu:uuid ?agendaitemId .
 


### PR DESCRIPTION
Reason for this change are flags on ACC.

Retracted / resubmitted flow needs the decision result code , but the decision is not yet propagated.
So choose to add it here.

Also needed to know when the agenda-activity was started because this query sorts on meeting date.
so meeting[0] is always the most recent one, even if meeting[1] is the latest agenda-activity (earlier it time, only possible in this use case)

Since we also need the agenda-activity of designagenda A, it needs to be collected here.