### PR TITLE
KAS-4655: Check user is logged in before performing operations

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,7 +77,7 @@ app.get('/submissions/:id/for-meeting', async function(req, res, next) {
       data: { id: meeting.id, type: 'meetings', attributes: meeting }
     });
   }
-  return next({ message: 'The submission is not submitted to any meeting, please contact the administrator', status: 404 }); 
+  return next({ message: 'The submission is not submitted to any meeting, please contact the administrator', status: 404 });
 });
 
 app.post('/meetings/:id/submit-submission', async function(req, res, next) {
@@ -92,6 +92,7 @@ app.post('/meetings/:id/submit-submission', async function(req, res, next) {
   try {
     const meetingId = req.params.id;
     const meetingUri = req.body.meeting;
+    const sessionUri = req.headers['mu-session-id'];
 
     if (!meetingId) {
       return next({ message: 'Path parameter meeting ID was not set, cannot proceed', status: 400 });
@@ -103,6 +104,10 @@ app.post('/meetings/:id/submit-submission', async function(req, res, next) {
 
     if (!submissionUri) {
       return next({ message: 'Body does not contain a "submission" field, cannot proceed', status: 400 });
+    }
+
+    if (!(await sessionHasRole(sessionUri, [ROLES.ADMIN, ROLES.MINISTER, ROLES.KABINET_DOSSIERBEHEERDER]))) {
+      return next({ message: 'You do not have the correct role to perform this operation', status: 401 });
     }
 
     await submitSubmissionOnMeeting(submissionUri, meetingUri);


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4655

The call to submit a submission on a meeting should only work when logged in as a minister/kabinetdossierbeheerder (or admin who's impersonating). Logged out users should get a 401 response.

Can be checked using this kind of call in the console of a logged out tab:

```js
await fetch("http://localhost/meetings/67890890D84EB349369AC8A1/submit-submission", {
    "headers": {
        "Accept": "application/vnd.api+json",
        "Content-Type": "application/vnd.api+json",
    },
    "body": "{\"meeting\":\"http://themis.vlaanderen.be/id/zitting/67890890D84EB349369AC8A1\",\"submission\":\"http://themis.vlaanderen.be/id/indiening/679A27D9BDE990606BED672C\"}",
    "method": "POST"
});
```