### PR TITLE
KAS-4989: Regenerate decision reports when submitting new agendaitem

### DIFF
--- a/app.js
+++ b/app.js
@@ -271,8 +271,9 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
       signFlows,
     });
 
+    let didReorder = false;
     if (agendaitem.agendaitemType !== CONCEPTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT) {
-      await reorderAgendaitems(agenda.uri, agendaitem.agendaitemType);
+      didReorder = await reorderAgendaitems(agenda.uri, agendaitem.agendaitemType);
     }
 
     /**
@@ -289,6 +290,7 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
       data: {
         type: 'agendaitems',
         id: agendaitem.id,
+        didReorder,
       }
     });
 

--- a/lib/agendaitem-order.js
+++ b/lib/agendaitem-order.js
@@ -86,6 +86,7 @@ async function reorderAgendaitems(agenda, agendaitemType) {
   if (toBeUpdatedAgendaitems.length) {
     await applyAgendaitemsOrder(toBeUpdatedAgendaitems);
   }
+  return toBeUpdatedAgendaitems.length > 0;
 }
 
 /* We sort on the mandatee priority. To do this, we simply cast the array of


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4989

After inserting new agendaitems, we check whether we need to reorder the agendaitems according to their mandatees' priorities. From now on, if a reordering happens, we will inform the frontend about it. This is useful for e.g. regenerating the agenda's decision reports.