### PR TITLE
KAS-5035 split insert query, add verification and deletion in case of…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ agenda-submission:
   image: kanselarij/agenda-submission-service
   environment:
     CACHE_CLEAR_TIMEOUT: 5000 # adds a timeout before sending a response, to give the cache time to clear.
+    SINGLE_PERSIST_QUERY: "true" # if the INSERT data should be 1 large insert intead of smaller inserts. Possible values: "yes", "true", true, "1", 1, "on" 
 ```
 
 Add rules to the dispatcher configuration file to dispatch requests to this service:

--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ import { CONCEPTS, ROLES, URI_BASES } from './constants';
 import { getOpenMeetings, getMeetingForSubmission, isMeetingClosed, submitSubmissionOnMeeting } from './lib/meeting';
 import { isSubcaseOnAgenda } from './lib/subcase';
 import { getRelatedResources } from './lib/data-fetching';
-import { persistRecords } from './lib/data-persisting';
+import { persistAndVerifyRecords } from './lib/data-persisting';
 import { reorderAgendaitems } from './lib/agendaitem-order';
 import { getAgenda, getAgendasForSubcase, isApprovedAgenda } from './lib/agenda';
 import { isLoggedIn, sessionHasRole } from './lib/session';
@@ -266,7 +266,7 @@ app.post('/meetings/:id/submit', async function(req, res, next) {
       };
     }
 
-    await persistRecords({
+    await persistAndVerifyRecords({
       agendaitem,
       treatment,
       agendaActivity,

--- a/lib/data-persisting.js
+++ b/lib/data-persisting.js
@@ -1,5 +1,6 @@
 import {
   update,
+  query,
   sparqlEscapeUri,
   sparqlEscapeString,
   sparqlEscapeDateTime,
@@ -8,13 +9,81 @@ import {
 
 import { TYPES } from '../constants';
 
+const SINGLE_PERSIST_QUERY = ["yes", "true", true, "1", 1, "on"].includes(process.env.SINGLE_PERSIST_QUERY); // default false
+
 function sparqlEscapeBoolCustom(value) {
   return value
     ? '"true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>'
     : '"false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean>';
 }
 
-async function persistRecords({
+async function persistAndVerifyRecords({
+  agenda,
+  signFlows,
+  newSubmission,
+  newsItem,
+  agendaActivity,
+  decisionActivity,
+  treatment,
+  agendaitem,
+}) {
+  let recordsVerified = false;
+  try {
+    if (!SINGLE_PERSIST_QUERY) {
+      await _persistAgendaActivity(agendaActivity);
+      await _persistDecisionActivity(decisionActivity);
+      await _persistAgendaItemTreatment(treatment);
+      await _persistAgendaitem(agendaitem);
+      if (newSubmission) {
+        await _persistSubmissionActivity(newSubmission);
+      }
+      if (newsItem) {
+        await _persistNewsItem(newsItem);
+      }
+      await _updateSignFlowAndAgendaModified(agenda, signFlows, decisionActivity);
+    } else { 
+      await _bulkPersist({
+        agenda,
+        signFlows,
+        newSubmission,
+        newsItem,
+        agendaActivity,
+        decisionActivity,
+        treatment,
+        agendaitem,
+      });
+    }
+
+    recordsVerified = await _verifyRecords({
+      agendaitem,
+      treatment,
+      agendaActivity,
+      decisionActivity,
+      newSubmission,
+      newsItem,
+      agenda,
+      signFlows,
+    });
+  } catch (error) {
+    console.error("Failed to verify records after creation");
+  } finally {
+    if (!recordsVerified) {
+      await _deleteRecords({
+        agendaitem,
+        treatment,
+        agendaActivity,
+        decisionActivity,
+        newSubmission,
+        newsItem,
+      });
+      throw new Error(
+        "Could not verify created data, incorrect data has been deleted and it should be possible to submit for meeting again"
+      );
+    }
+  }
+}
+
+async function _bulkPersist({
   agenda,
   signFlows,
   newSubmission,
@@ -109,6 +178,320 @@ DELETE {
   await update(queryString);
 }
 
+async function _persistAgendaActivity(agendaActivity) {
+  const queryString = `
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+  INSERT DATA {
+    ${sparqlEscapeUri(agendaActivity.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.agendaActivity)} ;
+    mu:uuid ${sparqlEscapeString(agendaActivity.id)} ;
+    dossier:startDatum ${sparqlEscapeDateTime(agendaActivity.startDate)} ;
+    besluitvorming:vindtPlaatsTijdens ${sparqlEscapeUri(agendaActivity.subcase)} ;
+    prov:wasInformedBy ${agendaActivity.submissionActivities.map((a) => sparqlEscapeUri(a.uri)).join(', ')} .
+  }`;
+  await update(queryString);
+}
+
+async function _persistDecisionActivity(decisionActivity) {
+const queryString = `
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+  INSERT DATA {
+    ${sparqlEscapeUri(decisionActivity.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.decisionActivity)} ;
+    mu:uuid ${sparqlEscapeString(decisionActivity.id)} ;
+    ${decisionActivity.secretary ? `prov:wasAssociatedWith ${sparqlEscapeUri(decisionActivity.secretary)} ;` : ''}
+    ${decisionActivity.decisionResultCode ? `besluitvorming:resultaat ${sparqlEscapeUri(decisionActivity.decisionResultCode)} ;` : ''}
+    dossier:Activiteit.startdatum ${sparqlEscapeDateTime(decisionActivity.startDate)} ;
+    ext:beslissingVindtPlaatsTijdens ${sparqlEscapeUri(decisionActivity.subcase)} .
+  }`;
+  await update(queryString);
+}
+
+async function _persistAgendaItemTreatment(treatment) {
+  const queryString = `
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+  INSERT DATA {
+    ${sparqlEscapeUri(treatment.uri)} a ${sparqlEscapeUri(TYPES.treatment)} ;
+    mu:uuid ${sparqlEscapeString(treatment.id)} ;
+    dct:created ${sparqlEscapeDateTime(treatment.created)} ;
+    dct:modified ${sparqlEscapeDateTime(treatment.modified)} ;
+    besluitvorming:heeftBeslissing ${sparqlEscapeUri(treatment.decisionActivity)} .
+  }`;
+  await update(queryString);
+}
+
+async function _persistAgendaitem(agendaitem) {
+  const queryString = `PREFIX schema: <http://schema.org/>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+  INSERT DATA {
+    ${sparqlEscapeUri(agendaitem.uri)} a ${sparqlEscapeUri(TYPES.agendaitem)} ;
+    mu:uuid ${sparqlEscapeString(agendaitem.id)} ;
+    dct:created ${sparqlEscapeDateTime(agendaitem.created)} ;
+    schema:position ${sparqlEscapeInt(agendaitem.number)} ;
+    besluitvorming:korteTitel ${sparqlEscapeString(agendaitem.shortTitle)} ;
+    ${agendaitem.title ? `dct:title ${sparqlEscapeString(agendaitem.title)} ;` : ''}
+    ext:formeelOK ${sparqlEscapeUri(agendaitem.formallyOk)} ;
+    ${agendaitem.mandatees?.length ? `ext:heeftBevoegdeVoorAgendapunt ${agendaitem.mandatees.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ${agendaitem.pieces?.length ? `besluitvorming:geagendeerdStuk ${agendaitem.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ${agendaitem.linkedPieces?.length ? `ext:bevatReedsBezorgdAgendapuntDocumentversie ${agendaitem.linkedPieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ext:isGoedkeuringVanDeNotulen ${sparqlEscapeBoolCustom(agendaitem.isApproval)} ;
+    dct:type ${sparqlEscapeUri(agendaitem.agendaitemType)} .
+
+    ${sparqlEscapeUri(agendaitem.treatment)} dct:subject ${sparqlEscapeUri(agendaitem.uri)} .
+    ${sparqlEscapeUri(agendaitem.agendaActivity)} besluitvorming:genereertAgendapunt ${sparqlEscapeUri(agendaitem.uri)} .
+    ${sparqlEscapeUri(agendaitem.agenda)} dct:hasPart ${sparqlEscapeUri(agendaitem.uri)} .
+  }`;
+  await update(queryString);
+}
+
+async function _persistSubmissionActivity(newSubmission) {
+  const queryString = `
+  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+  PREFIX prov: <http://www.w3.org/ns/prov#>
+  PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+  INSERT DATA {
+    ${sparqlEscapeUri(newSubmission.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.submissionActivity)} ;
+    mu:uuid ${sparqlEscapeString(newSubmission.id)} ;
+    dossier:Activiteit.startdatum ${sparqlEscapeDateTime(newSubmission.startDate)} ;
+    ${newSubmission.pieces?.length ? `prov:generated ${newSubmission.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ext:indieningVindtPlaatsTijdens ${sparqlEscapeUri(newSubmission.subcase)} .
+  }`;
+  await update(queryString);  
+}
+
+async function _persistNewsItem(newsItem) {
+  const queryString = `
+  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+  PREFIX prov: <http://www.w3.org/ns/prov#>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+  INSERT DATA {
+    ${sparqlEscapeUri(newsItem.uri)} a ${sparqlEscapeUri(TYPES.newsItem)} ;
+    mu:uuid ${sparqlEscapeString(newsItem.id)} ;
+    prov:wasDerivedFrom ${sparqlEscapeUri(newsItem.treatment)} ;
+    dct:title ${sparqlEscapeString(newsItem.title)} ;
+    ${newsItem.htmlContent ? `nie:htmlContent ${sparqlEscapeString(newsItem.htmlContent)} ;` : ''}
+    ext:afgewerkt ${sparqlEscapeBoolCustom(newsItem.finished)} ;
+    ext:inNieuwsbrief ${sparqlEscapeBoolCustom(newsItem.inNewsletter)} .
+  }`;
+  await update(queryString);
+}
+
+async function _updateSignFlowAndAgendaModified(agenda, signFlows, decisionActivity) {
+  const queryString = `
+  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+  PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+  PREFIX dct: <http://purl.org/dc/terms/>
+
+  DELETE {
+    ${sparqlEscapeUri(agenda.uri)} dct:modified ?oldModified .
+    ${signFlows.length ? signFlows.map((signFlow) => {
+      return `${sparqlEscapeUri(signFlow.uri)} sign:heeftBeslissing ${sparqlEscapeUri(signFlow.decisionActivity.at(0))} .`
+    }).join('  \n') : ''}
+  } INSERT {
+    ${sparqlEscapeUri(agenda.uri)} dct:modified ${sparqlEscapeDateTime(new Date())} .
+    ${signFlows.length ? signFlows.map((signFlow) => {
+      return `${sparqlEscapeUri(signFlow.uri)} sign:heeftBeslissing ${sparqlEscapeUri(decisionActivity.uri)} .`
+    }).join('  \n') : ''}
+  } WHERE {
+    ${sparqlEscapeUri(agenda.uri)} dct:modified ?oldModified .
+  }
+  `
+  await update(queryString);
+}
+
+
+async function _verifyRecords({
+  agenda,
+  signFlows,
+  newSubmission,
+  newsItem,
+  agendaActivity,
+  decisionActivity,
+  treatment,
+  agendaitem
+}) {
+  let queryString = `PREFIX schema: <http://schema.org/>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+ASK WHERE {
+  ${sparqlEscapeUri(agendaActivity.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.agendaActivity)} ;
+    mu:uuid ${sparqlEscapeString(agendaActivity.id)} ;
+    dossier:startDatum ${sparqlEscapeDateTime(agendaActivity.startDate)} ;
+    besluitvorming:vindtPlaatsTijdens ${sparqlEscapeUri(agendaActivity.subcase)} ;
+    prov:wasInformedBy ${agendaActivity.submissionActivities.map((a) => sparqlEscapeUri(a.uri)).join(', ')} .
+
+  ${sparqlEscapeUri(decisionActivity.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.decisionActivity)} ;
+    mu:uuid ${sparqlEscapeString(decisionActivity.id)} ;
+    ${decisionActivity.secretary ? `prov:wasAssociatedWith ${sparqlEscapeUri(decisionActivity.secretary)} ;` : ''}
+    ${decisionActivity.decisionResultCode ? `besluitvorming:resultaat ${sparqlEscapeUri(decisionActivity.decisionResultCode)} ;` : ''}
+    dossier:Activiteit.startdatum ${sparqlEscapeDateTime(decisionActivity.startDate)} ;
+    ext:beslissingVindtPlaatsTijdens ${sparqlEscapeUri(decisionActivity.subcase)} .
+
+  ${sparqlEscapeUri(treatment.uri)} a ${sparqlEscapeUri(TYPES.treatment)} ;
+    mu:uuid ${sparqlEscapeString(treatment.id)} ;
+    dct:created ${sparqlEscapeDateTime(treatment.created)} ;
+    dct:modified ${sparqlEscapeDateTime(treatment.modified)} ;
+    besluitvorming:heeftBeslissing ${sparqlEscapeUri(treatment.decisionActivity)} .
+
+  ${sparqlEscapeUri(agendaitem.uri)} a ${sparqlEscapeUri(TYPES.agendaitem)} ;
+    mu:uuid ${sparqlEscapeString(agendaitem.id)} ;
+    dct:created ${sparqlEscapeDateTime(agendaitem.created)} ;
+    schema:position ?anyNumber ;
+    besluitvorming:korteTitel ${sparqlEscapeString(agendaitem.shortTitle)} ;
+    ${agendaitem.title ? `dct:title ${sparqlEscapeString(agendaitem.title)} ;` : ''}
+    ext:formeelOK ${sparqlEscapeUri(agendaitem.formallyOk)} ;
+    ${agendaitem.mandatees?.length ? `ext:heeftBevoegdeVoorAgendapunt ${agendaitem.mandatees.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ${agendaitem.pieces?.length ? `besluitvorming:geagendeerdStuk ${agendaitem.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ${agendaitem.linkedPieces?.length ? `ext:bevatReedsBezorgdAgendapuntDocumentversie ${agendaitem.linkedPieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ext:isGoedkeuringVanDeNotulen ${sparqlEscapeBoolCustom(agendaitem.isApproval)} ;
+    dct:type ${sparqlEscapeUri(agendaitem.agendaitemType)} .
+
+  ${sparqlEscapeUri(agendaitem.treatment)} dct:subject ${sparqlEscapeUri(agendaitem.uri)} .
+  ${sparqlEscapeUri(agendaitem.agendaActivity)} besluitvorming:genereertAgendapunt ${sparqlEscapeUri(agendaitem.uri)} .
+  ${sparqlEscapeUri(agendaitem.agenda)} dct:hasPart ${sparqlEscapeUri(agendaitem.uri)} .`;
+
+  if (newSubmission) {
+    queryString += `
+  ${sparqlEscapeUri(newSubmission.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.submissionActivity)} ;
+    mu:uuid ${sparqlEscapeString(newSubmission.id)} ;
+    dossier:Activiteit.startdatum ${sparqlEscapeDateTime(newSubmission.startDate)} ;
+    ${newSubmission.pieces?.length ? `prov:generated ${newSubmission.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
+    ext:indieningVindtPlaatsTijdens ${sparqlEscapeUri(newSubmission.subcase)} .`;
+  }
+
+  if (newsItem) {
+    queryString += `
+  ${sparqlEscapeUri(newsItem.uri)} a ${sparqlEscapeUri(TYPES.newsItem)} ;
+    mu:uuid ${sparqlEscapeString(newsItem.id)} ;
+    prov:wasDerivedFrom ${sparqlEscapeUri(newsItem.treatment)} ;
+    dct:title ${sparqlEscapeString(newsItem.title)} ;
+    ${newsItem.htmlContent ? `nie:htmlContent ${sparqlEscapeString(newsItem.htmlContent)} ;` : ''}
+    ext:afgewerkt ${sparqlEscapeBoolCustom(newsItem.finished)} ;
+    ext:inNieuwsbrief ${sparqlEscapeBoolCustom(newsItem.inNewsletter)} .`;
+  }
+  queryString += `}`
+  const results = await query(queryString);
+  return results.boolean;
+}
+
+async function _deleteRecords({
+  newSubmission,
+  newsItem,
+  agendaActivity,
+  decisionActivity,
+  treatment,
+  agendaitem,
+}) {
+  await update(`
+    DELETE WHERE {
+      ${sparqlEscapeUri(agendaActivity.uri)} ?p ?o .
+    }
+    `);
+
+  await update(`
+    DELETE WHERE {
+      ?s ?p ${sparqlEscapeUri(agendaActivity.uri)} .
+  }
+    `);
+
+  await update(`
+    DELETE WHERE {
+      ${sparqlEscapeUri(decisionActivity.uri)} ?p ?o .
+  }
+    `);
+
+  await update(`
+    DELETE WHERE {
+      ?s ?p ${sparqlEscapeUri(decisionActivity.uri)} .
+  }
+    `);
+
+  await update(`
+    DELETE WHERE {
+      ${sparqlEscapeUri(treatment.uri)} ?p ?o .
+  }
+    `);
+
+  await update(`
+    DELETE WHERE {
+      ?s ?p ${sparqlEscapeUri(treatment.uri)} .
+  }
+    `);
+
+  await update(`
+    DELETE WHERE {
+      ${sparqlEscapeUri(agendaitem.uri)} ?p ?o .
+  }
+    `);
+
+  await update(`
+    DELETE WHERE {
+      ?s ?p ${sparqlEscapeUri(agendaitem.uri)} .
+  }
+    `);
+
+  if (newSubmission) {
+    await update(`
+      DELETE WHERE {
+        ${sparqlEscapeUri(newSubmission.uri)} ?p ?o .
+    }
+      `);
+
+    await update(`
+      DELETE WHERE {
+        ?s ?p ${sparqlEscapeUri(newSubmission.uri)} .
+    }
+      `);
+  }
+
+  if (newsItem) {
+    await update(`
+      DELETE WHERE {
+        ${sparqlEscapeUri(newsItem.uri)} ?p ?o .
+    }
+      `);
+
+    await update(`
+      DELETE WHERE {
+        ?s ?p ${sparqlEscapeUri(newsItem.uri)} .
+    }
+      `);
+  }
+}
+
 export {
-  persistRecords,
+  persistAndVerifyRecords,
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5035

- made smaller queries (default on, the old INSERT query can be enabled with a ENV prop for later)
- added an ASK query where we check if most* of the data exists
- if the ASK fails > delete all data in tiny queries (to avoid using optionals in deletes)

*not all inserted data needs to be checked like agenda modified date which changes constantly. or agendaitem number since reordering can happen (used `?anyNumber` to check instead of actual value)

note: the smaller query in `_persistAgendaitem` can and will be a large query if many documents are present (like the GRUP dossiers)
I was thinking of separating the documents and adding them batched. but held off for now.