### PR TITLE
KAS-5075 Batch persist and verify pieces

### DIFF
--- a/lib/data-persisting.js
+++ b/lib/data-persisting.js
@@ -10,6 +10,7 @@ import {
 import { TYPES } from '../constants';
 
 const SINGLE_PERSIST_QUERY = ["yes", "true", true, "1", 1, "on"].includes(process.env.SINGLE_PERSIST_QUERY); // default false
+const PIECE_QUERY_BATCH_SIZE = parseInt(process.env.PIECE_QUERY_BATCH_SIZE) || 25 ;
 
 function sparqlEscapeBoolCustom(value) {
   return value
@@ -41,7 +42,7 @@ async function persistAndVerifyRecords({
         await _persistNewsItem(newsItem);
       }
       await _updateSignFlowAndAgendaModified(agenda, signFlows, decisionActivity);
-    } else { 
+    } else {
       await _bulkPersist({
         agenda,
         signFlows,
@@ -66,6 +67,7 @@ async function persistAndVerifyRecords({
     });
   } catch (error) {
     console.error("Failed to verify records after creation");
+    console.log(error);
   } finally {
     if (!recordsVerified) {
       await _deleteRecords({
@@ -233,6 +235,27 @@ PREFIX dct: <http://purl.org/dc/terms/>
   await update(queryString);
 }
 
+/* Persist links to pieces for the supplied resource in the triplestore in batch.
+  resourceUri: the subject of the triple resource, predicate, piece
+  pieces: the array of piece URIs
+  predicate: the full URI (without <>) of the predicate used to link from resource to piece
+*/
+async function _persistPieces(resourceUri, pieces, predicate) {
+  if (pieces?.length) {
+    const nrOfBatches = Math.ceil(pieces.length / PIECE_QUERY_BATCH_SIZE);
+    for (let currentBatch = 0; currentBatch < nrOfBatches; currentBatch++) {
+      const startIndex = currentBatch * PIECE_QUERY_BATCH_SIZE;
+      const endIndex = startIndex + PIECE_QUERY_BATCH_SIZE;
+      const currentPieces = pieces.slice(startIndex, endIndex);
+      const batchedQuery = `INSERT DATA {
+        ${sparqlEscapeUri(resourceUri)} ${sparqlEscapeUri(predicate)} ${currentPieces.map(sparqlEscapeUri).join(', ')} .
+      }
+      `;
+      await update(batchedQuery);
+    }
+  }
+}
+
 async function _persistAgendaitem(agendaitem) {
   const queryString = `PREFIX schema: <http://schema.org/>
 PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
@@ -250,8 +273,6 @@ PREFIX dct: <http://purl.org/dc/terms/>
     ${agendaitem.title ? `dct:title ${sparqlEscapeString(agendaitem.title)} ;` : ''}
     ext:formeelOK ${sparqlEscapeUri(agendaitem.formallyOk)} ;
     ${agendaitem.mandatees?.length ? `ext:heeftBevoegdeVoorAgendapunt ${agendaitem.mandatees.map(sparqlEscapeUri).join(', ')} ;` : ''}
-    ${agendaitem.pieces?.length ? `besluitvorming:geagendeerdStuk ${agendaitem.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
-    ${agendaitem.linkedPieces?.length ? `ext:bevatReedsBezorgdAgendapuntDocumentversie ${agendaitem.linkedPieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
     ext:isGoedkeuringVanDeNotulen ${sparqlEscapeBoolCustom(agendaitem.isApproval)} ;
     dct:type ${sparqlEscapeUri(agendaitem.agendaitemType)} .
 
@@ -260,6 +281,8 @@ PREFIX dct: <http://purl.org/dc/terms/>
     ${sparqlEscapeUri(agendaitem.agenda)} dct:hasPart ${sparqlEscapeUri(agendaitem.uri)} .
   }`;
   await update(queryString);
+  await _persistPieces(agendaitem.uri, agendaitem.pieces, "https://data.vlaanderen.be/ns/besluitvorming#geagendeerdStuk");
+  await _persistPieces(agendaitem.uri, agendaitem.linkedPieces, "http://mu.semte.ch/vocabularies/ext/bevatReedsBezorgdAgendapuntDocumentversie");
 }
 
 async function _persistSubmissionActivity(newSubmission) {
@@ -274,10 +297,10 @@ async function _persistSubmissionActivity(newSubmission) {
     ${sparqlEscapeUri(newSubmission.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.submissionActivity)} ;
     mu:uuid ${sparqlEscapeString(newSubmission.id)} ;
     dossier:Activiteit.startdatum ${sparqlEscapeDateTime(newSubmission.startDate)} ;
-    ${newSubmission.pieces?.length ? `prov:generated ${newSubmission.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
     ext:indieningVindtPlaatsTijdens ${sparqlEscapeUri(newSubmission.subcase)} .
   }`;
-  await update(queryString);  
+  await update(queryString);
+  await _persistPieces(newSubmission.uri, newSubmission.pieces, "http://www.w3.org/ns/prov#generated");
 }
 
 async function _persistNewsItem(newsItem) {
@@ -324,6 +347,31 @@ async function _updateSignFlowAndAgendaModified(agenda, signFlows, decisionActiv
   await update(queryString);
 }
 
+/* Verify the existence of pieces for the supplied resource in the triplestore in batch.
+  resourceUri: the subject of the triple resource, predicate, piece
+  pieces: the array of piece URIs
+  predicate: the full URI (without <>) of the predicate used to link from resource to piece
+*/
+async function _verifyPieces(resourceUri, pieces, predicate) {
+  if (pieces?.length) {
+    const nrOfBatches = Math.ceil(pieces.length / PIECE_QUERY_BATCH_SIZE);
+    for (let currentBatch = 0; currentBatch < nrOfBatches; currentBatch++) {
+      const startIndex = currentBatch * PIECE_QUERY_BATCH_SIZE;
+      const endIndex = startIndex + PIECE_QUERY_BATCH_SIZE;
+      const currentPieces = pieces.slice(startIndex, endIndex);
+      const batchedQuery = `ASK WHERE {
+        ${sparqlEscapeUri(resourceUri)} ${sparqlEscapeUri(predicate)} ${currentPieces.map(sparqlEscapeUri).join(', ')} .
+      }
+      `;
+      const batchedResults = await query(batchedQuery);
+      if (!batchedResults.boolean) {
+        // as soon as one of the queries fails, the whole process is considered failed
+        return false;
+      }
+    }
+  }
+  return true;
+}
 
 async function _verifyRecords({
   agenda,
@@ -335,6 +383,7 @@ async function _verifyRecords({
   treatment,
   agendaitem
 }) {
+  // first verify the existence of the agendaitem and related metdata
   let queryString = `PREFIX schema: <http://schema.org/>
 PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -374,8 +423,6 @@ ASK WHERE {
     ${agendaitem.title ? `dct:title ${sparqlEscapeString(agendaitem.title)} ;` : ''}
     ext:formeelOK ${sparqlEscapeUri(agendaitem.formallyOk)} ;
     ${agendaitem.mandatees?.length ? `ext:heeftBevoegdeVoorAgendapunt ${agendaitem.mandatees.map(sparqlEscapeUri).join(', ')} ;` : ''}
-    ${agendaitem.pieces?.length ? `besluitvorming:geagendeerdStuk ${agendaitem.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
-    ${agendaitem.linkedPieces?.length ? `ext:bevatReedsBezorgdAgendapuntDocumentversie ${agendaitem.linkedPieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
     ext:isGoedkeuringVanDeNotulen ${sparqlEscapeBoolCustom(agendaitem.isApproval)} ;
     dct:type ${sparqlEscapeUri(agendaitem.agendaitemType)} .
 
@@ -388,7 +435,6 @@ ASK WHERE {
   ${sparqlEscapeUri(newSubmission.uri)} a ${sparqlEscapeUri(TYPES.activity)}, ${sparqlEscapeUri(TYPES.submissionActivity)} ;
     mu:uuid ${sparqlEscapeString(newSubmission.id)} ;
     dossier:Activiteit.startdatum ${sparqlEscapeDateTime(newSubmission.startDate)} ;
-    ${newSubmission.pieces?.length ? `prov:generated ${newSubmission.pieces.map(sparqlEscapeUri).join(', ')} ;` : ''}
     ext:indieningVindtPlaatsTijdens ${sparqlEscapeUri(newSubmission.subcase)} .`;
   }
 
@@ -404,7 +450,25 @@ ASK WHERE {
   }
   queryString += `}`
   const results = await query(queryString);
-  return results.boolean;
+  if (!results.boolean) {
+    return false;
+  }
+  // now check if all pieces were added. We batch this, since the list may include hundreds of pieces
+  const piecesExist = await _verifyPieces(agendaitem.uri, agendaitem.pieces, "https://data.vlaanderen.be/ns/besluitvorming#geagendeerdStuk");
+  if (!piecesExist) {
+    return false;
+  }
+  const linkedPiecesExist = await _verifyPieces(agendaitem.uri, agendaitem.linkedPieces, "http://mu.semte.ch/vocabularies/ext/bevatReedsBezorgdAgendapuntDocumentversie");
+  if (!linkedPiecesExist) {
+    return false;
+  }
+  if (newSubmission) {
+    const submittedPiecesExist = await _verifyPieces(newSubmission.uri, newSubmission.pieces, "http://www.w3.org/ns/prov#generated");
+    if (!submittedPiecesExist) {
+      return false;
+    }
+  }
+  return true;
 }
 
 async function _deleteRecords({


### PR DESCRIPTION
Batch size is controlled with `process.env.PIECE_QUERY_BATCH_SIZE`, default is 25.
This is the same batch size for INSERT and ASK queries.

Tested locally with up to 100 documents.