### PR TITLE
KAS-5144 add graphs to sudo query to ensure correct agenda versions are found

### DIFF
--- a/lib/meeting.js
+++ b/lib/meeting.js
@@ -61,6 +61,8 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX dct: <http://purl.org/dc/terms/>
 
 SELECT DISTINCT (?meeting AS ?uri) ?id ?serialnumber ?plannedStart ?type ?agendaId ?agenda
+FROM ${sparqlEscapeUri(GRAPHS.KANSELARIJ)}
+FROM ${sparqlEscapeUri(GRAPHS.PUBLIC)}
 WHERE {
   ?meeting
     a besluit:Vergaderactiviteit ;
@@ -86,7 +88,6 @@ ORDER BY DESC(?plannedStart)`;
 }
 
 async function getMeetingForSubmission(submissionId) {
-  // subtract 1 week to counter submissions done the same day as the agenda
   const queryString = `PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -96,6 +97,9 @@ PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX subm: <http://mu.semte.ch/vocabularies/ext/submissions/>
 
 SELECT DISTINCT (?meeting AS ?uri) ?id ?serialnumber ?plannedStart ?kind ?type ?agendaId ?agenda
+FROM ${sparqlEscapeUri(GRAPHS.SUBMISSION)}
+FROM ${sparqlEscapeUri(GRAPHS.KANSELARIJ)}
+FROM ${sparqlEscapeUri(GRAPHS.PUBLIC)}
 WHERE {
   ?submission a subm:Indiening ;
               mu:uuid ${sparqlEscapeString(submissionId)} ;


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5144

I think adding the graphs statements is enough.
The issue is that the cabinet graph is not up to date causing the query to not find the meeting with reopened agenda.
This is for the `getOpenMeetings` function

Also in the mentioned scenario all submissions for that meeting were throwing errors.
the fix was adding graph statements to the `getMeetingForSubmission` function